### PR TITLE
Add HF Hub push support for parquet embeddings

### DIFF
--- a/src/pu/__main__.py
+++ b/src/pu/__main__.py
@@ -47,6 +47,13 @@ def main():
     parser_percentiles.add_argument("--resize-mode", type=str, default="match", choices=["match", "fill"], help="Resize strategy (default: match).")
     parser_percentiles.add_argument("--output", type=str, default="data/percentiles.json", help="Output JSON path (default: data/percentiles.json).")
 
+    # Subparser for pushing embeddings to HF Hub
+    parser_push = subparsers.add_parser("push", help="Push parquet embeddings to a Hugging Face Hub dataset repo.")
+    parser_push.add_argument("parquet_file", nargs="?", default=None, help="Path to a specific parquet file to push.")
+    parser_push.add_argument("--all", action="store_true", dest="push_all", help="Push all data/*.parquet files.")
+    parser_push.add_argument("--dataset", required=True, help="HF dataset repo ID (e.g., 'Smith42/my-embeddings').")
+    parser_push.add_argument("--token", default=None, help="HF token (defaults to cached login).")
+
     # Subparser for benchmarking performance optimizations
     parser_benchmark = subparsers.add_parser("benchmark", help="Run performance benchmarks with optimization flags.")
     parser_benchmark.add_argument("--model", required=True, help="Model to benchmark (e.g., 'vit', 'dino').")
@@ -162,6 +169,17 @@ def main():
             resize_mode=args.resize_mode,
             output_path=args.output,
         )
+    elif args.command == "push":
+        from pu.hub import push_all, push_parquet
+
+        if args.parquet_file and args.push_all:
+            parser.error("Specify either a parquet file or --all, not both.")
+        elif args.push_all:
+            push_all("data", args.dataset, token=args.token)
+        elif args.parquet_file:
+            push_parquet(args.parquet_file, args.dataset, token=args.token)
+        else:
+            parser.error("Specify either a parquet file or --all.")
     elif args.command == "benchmark":
         from pu.benchmark import run_benchmark, BenchmarkConfig
 

--- a/src/pu/experiments.py
+++ b/src/pu/experiments.py
@@ -38,7 +38,6 @@ def run_experiment(model_alias, mode, output_dataset=None, batch_size=128, num_w
     else:
         modes = ["hsc", comp_mode]
     hf_ds = f"Smith42/{comp_mode}_hsc_crossmatched"
-    upload_ds = output_dataset
 
     def filterfun(idx):
         if "jwst" != comp_mode:
@@ -216,8 +215,12 @@ def run_experiment(model_alias, mode, output_dataset=None, batch_size=128, num_w
             )
 
             os.makedirs("data", exist_ok=True)
-            size_df.write_parquet(f"data/{comp_mode}_{model_alias}_{size}.parquet")
-            print(f"Saved to data/{comp_mode}_{model_alias}_{size}.parquet")
+            parquet_path = f"data/{comp_mode}_{model_alias}_{size}.parquet"
+            size_df.write_parquet(parquet_path)
+            print(f"Saved to {parquet_path}")
+            if output_dataset:
+                from pu.hub import push_parquet
+                push_parquet(parquet_path, output_dataset)
             print("Use 'platonic_universe compare' to compare against image model embeddings.")
             continue
 
@@ -298,4 +301,9 @@ def run_experiment(model_alias, mode, output_dataset=None, batch_size=128, num_w
             ]
         )
 
-        size_df.write_parquet(f"data/{comp_mode}_{model_alias}_{size}.parquet")
+        parquet_path = f"data/{comp_mode}_{model_alias}_{size}.parquet"
+        size_df.write_parquet(parquet_path)
+
+        if output_dataset:
+            from pu.hub import push_parquet
+            push_parquet(parquet_path, output_dataset)

--- a/src/pu/hub.py
+++ b/src/pu/hub.py
@@ -1,0 +1,166 @@
+"""Upload parquet embeddings to a Hugging Face Hub dataset repo."""
+
+from __future__ import annotations
+
+import glob
+import os
+import re
+
+import yaml
+
+
+def _parse_filename(parquet_path: str) -> tuple[str, str]:
+    """Parse a parquet filename into (subdirectory, filename_in_repo).
+
+    E.g. data/jwst_vit_base.parquet → ("jwst", "vit_base.parquet")
+    Config name is derived as "jwst_vit_base".
+    """
+    basename = os.path.basename(parquet_path)  # jwst_vit_base.parquet
+    stem = basename.removesuffix(".parquet")  # jwst_vit_base
+
+    # First token is the mode, rest is model_size
+    parts = stem.split("_", 1)
+    if len(parts) < 2:
+        raise ValueError(
+            f"Cannot parse '{basename}': expected {{mode}}_{{model}}_{{size}}.parquet"
+        )
+
+    mode = parts[0]
+    remainder = parts[1]  # e.g. vit_base
+    return mode, f"{remainder}.parquet", stem
+
+
+def _parse_readme_configs(readme_text: str) -> tuple[list[dict], str]:
+    """Extract YAML configs list and body from a README.md with front matter."""
+    match = re.match(r"^---\n(.*?)\n---\n?(.*)", readme_text, re.DOTALL)
+    if not match:
+        return [], ""
+
+    front_matter = yaml.safe_load(match.group(1)) or {}
+    body = match.group(2)
+    return front_matter.get("configs", []), body
+
+
+def _build_readme(configs: list[dict], body: str = "") -> str:
+    """Build a README.md string with YAML front matter configs."""
+    front_matter = yaml.dump(
+        {"configs": configs},
+        default_flow_style=False,
+        sort_keys=False,
+    )
+    return f"---\n{front_matter}---\n{body}"
+
+
+def push_parquet(
+    parquet_path: str,
+    repo_id: str,
+    *,
+    token: str | None = None,
+) -> None:
+    """Upload a single parquet file to an HF dataset repo.
+
+    1. Creates the repo if it doesn't exist.
+    2. Parses the filename to determine subdirectory layout.
+    3. Uploads the file.
+    4. Updates the README.md with a dataset config entry.
+    """
+    from huggingface_hub import HfApi
+
+    api = HfApi(token=token)
+
+    # Create repo (no-op if it already exists)
+    api.create_repo(repo_id, repo_type="dataset", exist_ok=True)
+
+    # Parse filename → subdirectory layout
+    mode, filename, config_name = _parse_filename(parquet_path)
+    path_in_repo = f"{mode}/{filename}"
+
+    # Upload the parquet file
+    api.upload_file(
+        path_or_fileobj=parquet_path,
+        path_in_repo=path_in_repo,
+        repo_id=repo_id,
+        repo_type="dataset",
+    )
+    print(f"Uploaded {parquet_path} → {repo_id}/{path_in_repo}")
+
+    # Update README.md with config entry
+    _update_readme_config(api, repo_id, config_name, path_in_repo)
+
+
+def _update_readme_config(
+    api,
+    repo_id: str,
+    config_name: str,
+    path_in_repo: str,
+) -> None:
+    """Download, update, and re-upload README.md with the new config entry."""
+    # Try to download existing README
+    try:
+        readme_path = api.hf_hub_download(
+            repo_id, "README.md", repo_type="dataset"
+        )
+        with open(readme_path) as f:
+            readme_text = f.read()
+    except Exception:
+        readme_text = ""
+
+    configs, body = _parse_readme_configs(readme_text)
+
+    # Upsert the config entry
+    new_entry = {
+        "config_name": config_name,
+        "data_files": [{"split": "train", "path": path_in_repo}],
+    }
+
+    # Replace existing entry with same config_name, or append
+    replaced = False
+    for i, cfg in enumerate(configs):
+        if cfg.get("config_name") == config_name:
+            configs[i] = new_entry
+            replaced = True
+            break
+    if not replaced:
+        configs.append(new_entry)
+
+    # Sort configs for deterministic output
+    configs.sort(key=lambda c: c["config_name"])
+
+    readme_content = _build_readme(configs, body)
+
+    import tempfile
+
+    with tempfile.NamedTemporaryFile(
+        mode="w", suffix=".md", delete=False
+    ) as tmp:
+        tmp.write(readme_content)
+        tmp_path = tmp.name
+
+    try:
+        api.upload_file(
+            path_or_fileobj=tmp_path,
+            path_in_repo="README.md",
+            repo_id=repo_id,
+            repo_type="dataset",
+        )
+    finally:
+        os.unlink(tmp_path)
+
+    print(f"Updated README.md configs in {repo_id} (config: {config_name})")
+
+
+def push_all(
+    data_dir: str,
+    repo_id: str,
+    *,
+    token: str | None = None,
+) -> None:
+    """Upload all .parquet files in data_dir to an HF dataset repo."""
+    files = sorted(glob.glob(os.path.join(data_dir, "*.parquet")))
+    if not files:
+        print(f"No .parquet files found in {data_dir}")
+        return
+
+    print(f"Found {len(files)} parquet file(s) to upload")
+    for path in files:
+        push_parquet(path, repo_id, token=token)


### PR DESCRIPTION
New hub.py module with push_parquet/push_all, wired into run_experiment via --output-dataset, and exposed as `pu push` subcommand.