### PR TITLE
Fix --test crash on DESI/SDSS modes

### DIFF
--- a/src/pu/utils.py
+++ b/src/pu/utils.py
@@ -39,8 +39,9 @@ def plot_sample_galaxies(hf_ds, modes, comp_mode, resize=True, resize_mode="matc
         axes = [axes]
 
     for col, sample in enumerate(samples):
-        # HSC row
-        hsc_img = flux_to_pil(sample["hsc_image"], "hsc", modes, resize=resize, resize_mode=resize_mode)
+        # HSC row — raw dataset uses "image", adapters rename to "hsc_image"
+        hsc_key = "hsc_image" if "hsc_image" in sample else "image"
+        hsc_img = flux_to_pil(sample[hsc_key], "hsc", modes, resize=resize, resize_mode=resize_mode)
         axes[0][col].imshow(hsc_img)
         axes[0][col].axis("off")
         if col == 0:


### PR DESCRIPTION
## Summary
- `plot_sample_galaxies` loads the raw HF dataset directly (not through an adapter), so the HSC column is `image` not `hsc_image`
- Falls back to `image` key when `hsc_image` isn't present

## Test plan
- `pu run --model vit --mode desi --test` no longer crashes