### PR TITLE
fix(dataset): with_format('torch') so streaming=False returns tensors

### DIFF
--- a/src/pu/pu_datasets/hf_crossmatched.py
+++ b/src/pu/pu_datasets/hf_crossmatched.py
@@ -20,6 +20,11 @@ class HFCrossmatchedAdapter(DatasetAdapter):
                 .map(processor)
                 .remove_columns([f"{mode}_image" for mode in modes])
             )
+            # When streaming=False (monkey-patched in run_extraction.py), .map()
+            # writes to Arrow which returns tensors as Python lists. with_format
+            # keeps them as torch tensors. Safe no-op for true streaming mode.
+            if hasattr(ds, "with_format"):
+                ds = ds.with_format("torch")
             return ds
         else:
             raise NotImplementedError(


### PR DESCRIPTION
## Summary
- `.map()` with `streaming=False` writes tensors to Arrow, which come back as Python lists
- Default DataLoader collation then produces lists of lists, triggering `'list' object has no attribute 'to'` when adapters call `batch[mode].to('cuda')`
- `with_format('torch')` restores tensor outputs; no-op for IterableDataset (streaming=True)

## Test plan
- [x] Local run: JWST + vit-base end-to-end succeeds, parquet uploaded to `kshitijd/platonic-embeddings/jwst/vit_base_blocks_layerwise.parquet`