### PR TITLE
fix(layerwise): drop mismatched-shape columns instead of skipping the model

### DIFF
--- a/src/pu/experiments_layerwise.py
+++ b/src/pu/experiments_layerwise.py
@@ -216,14 +216,19 @@ def extract_all_layers(
             cat = torch.cat(tensors).numpy()
             columns[col_name] = cat
 
-        # Verify all columns have the same row count
-        row_counts = {k: v.shape[0] for k, v in columns.items()}
-        unique_counts = set(row_counts.values())
-        if len(unique_counts) > 1:
-            print(f"[ERROR] Row count mismatch: {row_counts}")
-            continue
+        # Drop hooks that returned shapes without a batch dim (e.g. DinoV3's
+        # rope_embeddings outputs (seq_len, dim), so rows = batches × seq_len).
+        # The majority row count is the correct one — anything else is garbage.
+        if columns:
+            from collections import Counter
+            counts = Counter(v.shape[0] for v in columns.values())
+            expected = counts.most_common(1)[0][0]
+            dropped = [k for k, v in columns.items() if v.shape[0] != expected]
+            for k in dropped:
+                print(f"[drop] {k}: {columns[k].shape[0]} rows (expected {expected})")
+                del columns[k]
 
-        n_samples = list(row_counts.values())[0] if row_counts else 0
+        n_samples = next(iter(columns.values())).shape[0] if columns else 0
         print(f"[{model_alias} {size}] {n_samples} samples, {len(columns)} columns")
 
         df = pl.DataFrame({


### PR DESCRIPTION
## Summary
- DinoV3's `rope_embeddings` (and likely similar modules in other models) outputs shape `(seq_len, dim)` with no batch dim
- `_generic_pool` passes 2D tensors through unchanged, so when concatenated across batches the column has `batches × seq_len` rows instead of `n_samples`
- Previously we detected the mismatch and `continue`d, skipping the entire model — so DinoV3 layerwise extraction silently produced nothing
- Now we drop just the offending columns and keep the rest

## Example: DinoV3-vitb16 on JWST (1496 samples, batch_size=32)

Before this fix:
```
[ERROR] could not create a new DataFrame: height of column 'rope_embeddings_hsc' (9212) does not match height of column 'embeddings_hsc' (1496)
Summary: 0 done, 0 skipped, 4 failed
```

`rope_embeddings` outputs `(196, 768)` — 196 patches, no batch dim — so after concat across 47 batches of 32 samples we get 47 × 196 = 9212 rows instead of 1496.

After this fix:
```
  [drop] rope_embeddings_hsc: 9212 rows (expected 1496)
  [drop] rope_embeddings_jwst: 9212 rows (expected 1496)
  1496 samples, 30 columns
  Saved to .../jwst_dinov3_vitb16_blocks_layerwise.parquet
```

Only the 2 rope_embeddings columns are dropped; all 30 other layer × mode combinations (embeddings, 12 encoder blocks, layernorm × 2 modes) are preserved.

## Test plan
- [x] Local run: DinoV3 vits16 / vits16plus / vitb16 / vitl16 × JWST → 4 parquets uploaded to \`kshitijd/platonic-embeddings\` with the 2 rope_embeddings cols dropped, everything else intact