### PR TITLE
fix(sdss,desi): with_format('torch') so streaming=False returns tensors

### DIFF
--- a/src/pu/pu_datasets/desi.py
+++ b/src/pu/pu_datasets/desi.py
@@ -25,6 +25,10 @@ class DESIAdapter(DatasetAdapter):
             .map(processor)
             .remove_columns(["hsc_image"])
         )
+        # See hf_crossmatched.py: required when streaming=False so .map() output
+        # is returned as torch tensors instead of Python lists.
+        if hasattr(ds, "with_format"):
+            ds = ds.with_format("torch")
         return ds
 
 # Register adapter

--- a/src/pu/pu_datasets/sdss.py
+++ b/src/pu/pu_datasets/sdss.py
@@ -25,6 +25,10 @@ class SDSSAdapter(DatasetAdapter):
             .map(processor)
             .remove_columns(["hsc_image"])
         )
+        # See hf_crossmatched.py: required when streaming=False so .map() output
+        # is returned as torch tensors instead of Python lists.
+        if hasattr(ds, "with_format"):
+            ds = ds.with_format("torch")
         return ds
 
 # Register adapter


### PR DESCRIPTION
## Summary
Applies the same fix as PR #52 to the SDSS and DESI adapters.

When `streaming=False` (as used by `run_extraction.py` workers with an HF
cache), `.map()` serializes tensors to Arrow, which return as Python lists.
Without `with_format("torch")`, the DataLoader then produces lists-of-lists
and adapter code crashes with:

```
'list' object has no attribute 'to'
```

## Reproduction (before this fix)
```
  Claimed: sdss_convnext_nano
  [ERROR] 'list' object has no attribute 'to'
  Claimed: sdss_convnext_base
  [ERROR] 'list' object has no attribute 'to'
  ...
```

## Test plan
- [x] Local run on sdss + vit-mae_base: extraction now enters the forward-pass phase (16 hookable modules detected, no tensor-shape error)