### PR TITLE
fix(layerwise): drop stray .T on precomputed desi/sdss embeddings

### DIFF
--- a/src/pu/experiments_layerwise.py
+++ b/src/pu/experiments_layerwise.py
@@ -188,13 +188,15 @@ def extract_all_layers(
             for batch in tqdm(dl, desc=f"{model_alias} {size}"):
                 for m in modes:
                     if m == "desi":
-                        precomputed.setdefault(m, []).append(
-                            torch.tensor(np.array(batch["embeddings"])).T
-                        )
+                        emb = batch["embeddings"]
+                        if not isinstance(emb, torch.Tensor):
+                            emb = torch.as_tensor(np.asarray(emb))
+                        precomputed.setdefault(m, []).append(emb)
                     elif m == "sdss":
-                        precomputed.setdefault(m, []).append(
-                            torch.tensor(np.array(batch["embedding"])).T
-                        )
+                        emb = batch["embedding"]
+                        if not isinstance(emb, torch.Tensor):
+                            emb = torch.as_tensor(np.asarray(emb))
+                        precomputed.setdefault(m, []).append(emb)
                     else:
                         batch_layers = adapter.embed_all_layers_for_mode(batch, m, granularity=granularity)
                         if m not in layer_embs:


### PR DESCRIPTION
## Summary
- `batch['embeddings']` (DESI) and `batch['embedding']` (SDSS) already come back as `(batch, emb_dim)` after PR #54 added `with_format('torch')`
- Legacy `.T` transposed them to `(emb_dim, batch)`, which crashes on the final short batch with a different `batch` size

## Reproduction
```
  Claimed: sdss_vit-mae_base
  [ERROR] all the input array dimensions except for the concatenation axis
          must match exactly, but along dimension 1, the array at index 0
          has size 32 and the array at index 72 has size 15
```

2319 SDSS samples at batch_size=32 → 72 full batches of 32 + 1 final batch of 15 → shape mismatch on concat.

## After fix
```
  2319 samples, 17 columns
  Saved sdss_vit_base_blocks_layerwise.parquet
  Uploaded -> kshitijd/platonic-embeddings/sdss/vit_base_blocks_layerwise.parquet
```

## Test plan
- [x] Local run on sdss + vit_base: 2319 samples, 17 columns (16 HSC layers + 1 SDSS precomputed embedding), parquet uploaded successfully