### PR TITLE
fix(vjepa): do 16× temporal repeat in adapter, not preprocessor

### DIFF
--- a/scripts/vjepa_real_slice_repro.py
+++ b/scripts/vjepa_real_slice_repro.py
@@ -1,0 +1,111 @@
+"""Reproduce the vjepa Arrow/OOM failure on a small slice of the real
+Smith42/legacysurvey_hsc_crossmatched dataset, and verify this PR fixes it.
+
+Runs the exact flow run_extraction.py uses: stream a slice, materialize
+to an in-memory Dataset, apply HFCrossmatchedAdapter's .map(processor),
+feed through a DataLoader, run one forward pass through vjepa-large.
+
+Per-sample Arrow bytes:
+    pre-PR:  16 × 3 × 256 × 256 × 4 B = 12.58 MB
+    post-PR:  1 × 3 × 256 × 256 × 4 B =  0.79 MB
+
+At N=300 (two modes cached), pre-PR accumulates ~7.5 GB of Arrow data
+during .map() and is OOM-killed on a 31 GB box; post-PR fits in ~500 MB
+and completes cleanly.
+
+Observed locally (31 GB RAM, vjepa2-vitl):
+    pre-PR  N=300 → exit 137 (SIGKILL) during [4/4] .map()
+    post-PR N=300 → SUCCESS, ~7 min, hsc batch shape (2, 1, 3, 256, 256)
+
+Usage:
+    python scripts/vjepa_real_slice_repro.py <N>
+"""
+import os
+import sys
+import time
+import traceback
+
+# Point HF caches at /tmp (189 GB free on this box; ~/.cache only has ~80 GB).
+_TMP = "/tmp/pu_slice_hf_cache"
+os.environ["HF_HOME"] = _TMP
+os.environ["HF_HUB_CACHE"] = f"{_TMP}/hub"
+os.environ["HF_DATASETS_CACHE"] = f"{_TMP}/datasets"
+os.makedirs(_TMP, exist_ok=True)
+
+_REPO_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+os.chdir(_REPO_ROOT)  # data/percentiles.json is loaded by path
+sys.path.insert(0, os.path.join(_REPO_ROOT, "src"))
+
+import torch
+from datasets import Dataset, load_dataset
+from torch.utils.data import DataLoader
+from tqdm import tqdm
+
+from pu.models import get_adapter
+
+N = int(sys.argv[1]) if len(sys.argv) > 1 else 1500
+MODEL_ALIAS = "vjepa"
+SIZE = "large"
+HF_NAME = "facebook/vjepa2-vitl-fpc64-256"
+HF_DS = "Smith42/legacysurvey_hsc_crossmatched"
+
+
+def main():
+    print(f"N = {N}")
+    print(f"commit: ", end="", flush=True)
+    os.system("git -C /home/me/Desktop/platonic-universe rev-parse --short HEAD")
+
+    print(f"\n[1/4] streaming first {N} rows from {HF_DS} ...")
+    t0 = time.time()
+    stream = load_dataset(HF_DS, split="train", streaming=True)
+    # Drop the ~70 metadata columns up front — we only need the two image
+    # columns — so Dataset.from_list doesn't choke serializing nested Arrow.
+    stream = stream.select_columns(["hsc_image", "legacysurvey_image"])
+    rows = []
+    for i, row in enumerate(tqdm(stream.take(N), total=N, desc="stream")):
+        rows.append(row)
+        if i + 1 >= N:
+            break
+    print(f"  streamed {len(rows)} rows in {time.time()-t0:.1f} s")
+
+    print(f"\n[2/4] materializing to in-memory Dataset ...")
+    t0 = time.time()
+    ds_mem = Dataset.from_list(rows)
+    print(f"  done in {time.time()-t0:.1f} s — columns: {ds_mem.column_names}")
+
+    print(f"\n[3/4] loading {MODEL_ALIAS} {SIZE} ...")
+    adapter_cls = get_adapter(MODEL_ALIAS)
+    adapter = adapter_cls(HF_NAME, SIZE, alias=MODEL_ALIAS)
+    adapter.load()
+    print(f"  hookable modules: {adapter.get_num_layers()}")
+
+    print(f"\n[4/4] running HFCrossmatchedAdapter-style .map() + DataLoader ...")
+    modes = ["hsc", "legacysurvey"]
+    processor = adapter.get_preprocessor(modes, resize=True, resize_mode="match")
+    t0 = time.time()
+    ds = (
+        ds_mem.select_columns([f"{m}_image" for m in modes])
+              .map(processor)
+              .remove_columns([f"{m}_image" for m in modes])
+    )
+    ds = ds.with_format("torch")
+    print(f"  .map() completed in {time.time()-t0:.1f} s")
+
+    dl = DataLoader(ds, batch_size=2, num_workers=0)
+    with torch.no_grad():
+        for i, batch in enumerate(dl):
+            out = adapter.embed_all_layers_for_mode(batch, "hsc", granularity="blocks")
+            if i == 0:
+                print(f"  first batch OK — {len(out)} cols, hsc shape {tuple(batch['hsc'].shape)}")
+            if i >= 2:
+                break
+    print("\nSUCCESS")
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    except Exception as e:
+        print(f"\n[FAIL] {type(e).__name__}: {e}")
+        traceback.print_exc()
+        sys.exit(1)

--- a/src/pu/models/hf.py
+++ b/src/pu/models/hf.py
@@ -67,9 +67,27 @@ class HFAdapter(ModelAdapter):
     def get_preprocessor(self, modes: Iterable[str], resize: bool = False, resize_mode: str = "fill"):
         return PreprocessHF(modes, self.processor, alias=self.alias, resize=resize, resize_mode=resize_mode)
 
+    _VJEPA_NUM_FRAMES = 16
+
+    def _maybe_expand_video_frames(self, inputs: torch.Tensor) -> torch.Tensor:
+        """Expand single-frame video tensors to the 16-frame clip vjepa expects.
+
+        PreprocessHF caches one frame per sample to keep Arrow storage small;
+        the temporal repeat is applied here so the model sees its usual input.
+        """
+        if self.alias != "vjepa":
+            return inputs
+        # Dataloader gives (B, T, C, H, W). T should be 1 after the preprocessor
+        # fix; repeat along the temporal dim to reach _VJEPA_NUM_FRAMES.
+        if inputs.dim() == 5 and inputs.shape[1] < self._VJEPA_NUM_FRAMES:
+            reps = self._VJEPA_NUM_FRAMES // inputs.shape[1]
+            inputs = inputs.repeat(1, reps, 1, 1, 1)
+        return inputs
+
     def embed_for_mode(self, batch: Dict[str, Any], mode: str):
         # batch is a dict produced by the DataLoader; HF preprocess stores tensors under f"{mode}"
         inputs = batch[f"{mode}"].to("cuda")
+        inputs = self._maybe_expand_video_frames(inputs)
         with torch.no_grad():
             # Use AMP if enabled for faster inference with lower memory
             with torch.amp.autocast("cuda", enabled=self._use_amp, dtype=torch.float16):
@@ -127,6 +145,7 @@ class HFAdapter(ModelAdapter):
         granularity: str = "blocks",
     ) -> Dict[str, torch.Tensor]:
         inputs = batch[f"{mode}"].to("cuda")
+        inputs = self._maybe_expand_video_frames(inputs)
         hookable = self._get_hookable_model()
         model_output = {}
 

--- a/src/pu/preprocess.py
+++ b/src/pu/preprocess.py
@@ -69,9 +69,11 @@ class PreprocessHF:
                 if "pixel_values" in proc_out:
                     result[f"{mode}"] = proc_out["pixel_values"].squeeze()
                 elif "pixel_values_videos" in proc_out:
-                    result[f"{mode}"] = proc_out["pixel_values_videos"].repeat(
-                        1, 16, 1, 1, 1
-                    ).squeeze()
+                    # Store only the unexpanded single-frame tensor.
+                    # The 16× temporal repeat happens in the adapter forward
+                    # — keeping it out of the Arrow cache prevents RAM blowup
+                    # and pyarrow int32 list-offset overflow on large datasets.
+                    result[f"{mode}"] = proc_out["pixel_values_videos"].squeeze(0)
                 else:
                     raise KeyError(
                         "autoproc does not have 'pixel_values' or "

--- a/tests/test_vjepa_frame_expansion.py
+++ b/tests/test_vjepa_frame_expansion.py
@@ -1,0 +1,104 @@
+"""Reproducibility check: the tensor reaching the vjepa model is identical
+before and after moving the 16× temporal repeat out of the preprocessor.
+
+Main (pre-PR):
+    proc_out["pixel_values_videos"].repeat(1, 16, 1, 1, 1).squeeze()
+    -> DataLoader stacks -> (B, 16, 3, H, W) -> model
+
+This PR:
+    proc_out["pixel_values_videos"].squeeze(0)
+    -> DataLoader stacks -> (B, 1, 3, H, W)
+    -> HFAdapter._maybe_expand_video_frames -> (B, 16, 3, H, W) -> model
+
+No model or processor download — we synthesize the processor's
+`pixel_values_videos` output directly, which is the only contract the
+preprocessor depends on.
+"""
+import torch
+
+from pu.models.hf import HFAdapter
+
+
+def _fake_proc_out(seed: int = 0, H: int = 256, W: int = 256) -> torch.Tensor:
+    """Shape matches what AutoVideoProcessor returns for a single still image:
+    (batch=1, T_native=1, C=3, H, W)."""
+    g = torch.Generator().manual_seed(seed)
+    return torch.randn(1, 1, 3, H, W, generator=g)
+
+
+def _old_preprocess(proc_out: torch.Tensor) -> torch.Tensor:
+    """Reproduces the pre-PR preprocess branch."""
+    return proc_out.repeat(1, 16, 1, 1, 1).squeeze()
+
+
+def _new_preprocess(proc_out: torch.Tensor) -> torch.Tensor:
+    """Reproduces the post-PR preprocess branch."""
+    return proc_out.squeeze(0)
+
+
+def _stack_batch(per_sample_tensors):
+    """DataLoader's default collate stacks along a new leading batch dim."""
+    return torch.stack(per_sample_tensors, dim=0)
+
+
+class _VjepaStub(HFAdapter):
+    """Bypass HFAdapter.__init__'s model/processor loading — we only need
+    _maybe_expand_video_frames, which depends solely on self.alias."""
+
+    def __init__(self):
+        self.alias = "vjepa"
+
+    def load(self, compile_model: bool = False):
+        raise NotImplementedError  # not used
+
+    def get_preprocessor(self, *a, **k):
+        raise NotImplementedError  # not used
+
+    def embed_for_mode(self, *a, **k):
+        raise NotImplementedError  # not used
+
+
+def test_vjepa_model_input_unchanged():
+    """Old path and new path produce bit-identical (B, 16, 3, H, W) tensors."""
+    B = 3
+    per_sample_old = [_old_preprocess(_fake_proc_out(seed=i)) for i in range(B)]
+    per_sample_new = [_new_preprocess(_fake_proc_out(seed=i)) for i in range(B)]
+
+    # Shapes after per-sample preprocessing:
+    # old: (16, 3, 256, 256) — already repeated
+    # new: (1, 3, 256, 256) — single frame
+    assert per_sample_old[0].shape == (16, 3, 256, 256)
+    assert per_sample_new[0].shape == (1, 3, 256, 256)
+
+    batch_old = _stack_batch(per_sample_old)             # (B, 16, 3, 256, 256)
+    batch_new = _stack_batch(per_sample_new)             # (B,  1, 3, 256, 256)
+    assert batch_old.shape == (B, 16, 3, 256, 256)
+    assert batch_new.shape == (B,  1, 3, 256, 256)
+
+    # Old path is done — that's what the model sees on main.
+    # New path: adapter's helper expands T=1 -> T=16 before the forward.
+    adapter = _VjepaStub()
+    batch_new_expanded = adapter._maybe_expand_video_frames(batch_new)
+    assert batch_new_expanded.shape == (B, 16, 3, 256, 256)
+
+    # Byte-identical tensors reach the model.
+    assert torch.equal(batch_old, batch_new_expanded)
+
+
+def test_expand_is_noop_for_non_vjepa():
+    """The helper must not touch inputs for any other alias."""
+    x = torch.randn(2, 3, 224, 224)
+    for alias in ("vit", "dino", "dinov3", "clip", "convnext", "ijepa", "vit-mae"):
+        stub = _VjepaStub()
+        stub.alias = alias
+        y = stub._maybe_expand_video_frames(x)
+        assert y is x, f"alias {alias!r} unexpectedly mutated inputs"
+
+
+def test_expand_leaves_already_expanded_tensor_alone():
+    """If a future processor ever returns T>=16 natively, don't re-expand."""
+    stub = _VjepaStub()
+    x = torch.randn(2, 16, 3, 256, 256)
+    y = stub._maybe_expand_video_frames(x)
+    assert y.shape == x.shape
+    assert torch.equal(x, y)


### PR DESCRIPTION
## Summary

- **Root cause:** `PreprocessHF.__call__` (`src/pu/preprocess.py`) was expanding each vjepa sample to a 16-frame clip (`(16, 3, 256, 256)` ≈ 12.5 MB) before writing it to the HF `datasets` Arrow cache. On legacysurvey (~101k samples × 2 modes) this either OOM-killed workers with modest RAM or overflowed pyarrow's int32 list-offsets (~2 GB per list column), which produced the "offset overflow while concatenating arrays" error reported around sample ~999.
- **Fix:** cache the unexpanded single-frame tensor (`(1, 3, 256, 256)`) in `PreprocessHF`, and apply the 16× temporal repeat inside `HFAdapter.embed_for_mode` / `HFAdapter.embed_all_layers_for_mode` via a small `_maybe_expand_video_frames` helper guarded on `alias == "vjepa"`. Model inputs are bit-identical to before; only the Arrow footprint shrinks 16×.
- No changes to `run_extraction.py` or the existing drop-rows / non-tensor hook guards — those handle unrelated failure modes.

## Reproducibility — tensors reaching the model are unchanged

New unit tests: `tests/test_vjepa_frame_expansion.py` (runs in ~2 s, no model or dataset download).

1. **`test_vjepa_model_input_unchanged`** — synthesizes the processor's `(1, 1, 3, 256, 256)` output with a fixed seed, runs both paths end-to-end, and `torch.equal`-asserts the `(B, 16, 3, 256, 256)` batches are byte-identical:
   - **Old path** (main): `proc_out.repeat(1, 16, 1, 1, 1).squeeze()` → DataLoader stack.
   - **New path** (this PR): `proc_out.squeeze(0)` → DataLoader stack → `HFAdapter._maybe_expand_video_frames`.
2. **`test_expand_is_noop_for_non_vjepa`** — helper returns `inputs` with identical object identity for every other alias (`vit`, `dino`, `dinov3`, `clip`, `convnext`, `ijepa`, `vit-mae`).
3. **`test_expand_leaves_already_expanded_tensor_alone`** — if a future processor ever returns `T ≥ 16` natively, the helper is a no-op.

The tests use a `_VjepaStub` subclass that bypasses `HFAdapter.__init__`'s model/processor loading and only exercises `_maybe_expand_video_frames`, so they run offline in CI.

## Empirical pre/post comparison on real legacysurvey data

New script: `scripts/vjepa_real_slice_repro.py`. Streams N rows from `Smith42/legacysurvey_hsc_crossmatched`, materializes them in memory, then runs the exact `HFCrossmatchedAdapter → preprocessor → DataLoader → adapter.embed_all_layers_for_mode` flow that `run_extraction.py` uses.

Run locally (31 GB RAM, vjepa2-vitl), same N=300 slice on both code paths:

| Code path | Outcome | Where |
|---|---|---|
| **origin/main** (pre-PR) | `exit=137` (SIGKILL) | during `[4/4]` `.map()` |
| **this PR** | `SUCCESS`, ~7 min total | first batch OK, 37 cols, `hsc shape (2, 1, 3, 256, 256)` |

At N=300, pre-PR writes ~7.5 GB of Arrow list data (`300 × 2 modes × 12.5 MB`); post-PR writes ~470 MB (`300 × 2 × 0.79 MB`). On a cluster node with more RAM the pre-PR path survives the OOM but trips pyarrow's int32 list-offset limit instead around sample ~999 — same root cause, different symptom.

Logs from both runs are available locally; re-run via:
```
uv run python scripts/vjepa_real_slice_repro.py 300
```

## Test plan

- [x] Unit tests above pass locally.
- [x] Stub-dataset smoke test (40 synthetic HSC + legacysurvey rows) for vjepa-large: 37 cols, `(2, 1, 3, 256, 256)` batch, `EXTRACTION OK`.
- [x] CLIP-base regression check through the same stub pipeline — unchanged, 17 cols.
- [x] Real-data slice repro (N=300 from actual legacysurvey HF dataset): pre-PR OOM, post-PR success.
- [ ] Rerun `vjepa_large` / `vjepa_giant` / `vjepa_huge` on `legacysurvey` via `run_extraction.py` on the cluster; Arrow offset overflow should no longer occur.
- [ ] Spot-check a completed vjepa parquet's layer count and embedding dims against a same-family dino run to confirm nothing regressed.