### PR TITLE
fix(models): unwrap CLIP get_image_features (transformers 5.x); accept multi-patch llava-onevision

### DIFF
--- a/src/pu/models/hf.py
+++ b/src/pu/models/hf.py
@@ -19,6 +19,28 @@ from pu.preprocess import PreprocessHF
 _CLIP_FAMILY = {"clip"}
 
 
+def _clip_image_features(model, pixel_values: torch.Tensor) -> torch.Tensor:
+    """Run ``model.get_image_features`` and return the projected feature tensor.
+
+    transformers 4.x returns the projected ``(B, projection_dim)`` tensor
+    directly. transformers >=5 wraps it in ``BaseModelOutputWithPooling``,
+    where the same tensor lives in ``pooler_output``. Callers downstream of
+    this helper assume a plain ``torch.Tensor``.
+    """
+    out = model.get_image_features(pixel_values=pixel_values)
+    if isinstance(out, torch.Tensor):
+        return out
+    for attr in ("pooler_output", "image_embeds", "last_hidden_state"):
+        v = getattr(out, attr, None)
+        if isinstance(v, torch.Tensor):
+            return v
+    raise TypeError(
+        f"CLIPModel.get_image_features returned {type(out).__name__} with "
+        "no recognizable image-feature tensor field "
+        "(pooler_output / image_embeds / last_hidden_state)."
+    )
+
+
 class HFAdapter(ModelAdapter):
     """
     Adapter for HuggingFace vision models using AutoModel + AutoImageProcessor.
@@ -92,7 +114,7 @@ class HFAdapter(ModelAdapter):
             # Use AMP if enabled for faster inference with lower memory
             with torch.amp.autocast("cuda", enabled=self._use_amp, dtype=torch.float16):
                 if self.alias == "clip":
-                    outputs = self.model.get_image_features(pixel_values=inputs)
+                    outputs = _clip_image_features(self.model, inputs)
                     return outputs.float().detach()
                 outputs = self.model(inputs).last_hidden_state
                 if self.alias in ("vit", "vit-mae"):
@@ -170,7 +192,7 @@ class HFAdapter(ModelAdapter):
         if self.alias in _CLIP_FAMILY and hasattr(self.model, 'visual_projection'):
             with torch.no_grad():
                 with torch.amp.autocast("cuda", enabled=self._use_amp, dtype=torch.float16):
-                    projected = self.model.get_image_features(pixel_values=inputs)
+                    projected = _clip_image_features(self.model, inputs)
             results["visual_projection"] = projected.float().detach()
 
         return results
@@ -247,6 +269,11 @@ class VLMAdapter(HFAdapter):
         B = pv.shape[0]
         prompt = self._PROMPTS.get(self.alias, " ")
         pv_cpu = pv.cpu().float()
+        # llava-onevision returns multi-patch pixel_values shaped
+        # (B, P, C, H, W); take the canonical first patch since the
+        # processor below re-tiles from a single PIL image anyway.
+        if pv_cpu.dim() == 5:
+            pv_cpu = pv_cpu[:, 0]
         pv_cpu = (pv_cpu - pv_cpu.min()) / (pv_cpu.max() - pv_cpu.min() + 1e-8)
         pv_cpu = (pv_cpu * 255).byte()
         pil_images = [

--- a/tests/test_hf_clip_and_llava_ov.py
+++ b/tests/test_hf_clip_and_llava_ov.py
@@ -1,0 +1,119 @@
+"""Coverage for two cluster-driven fixes:
+
+1. transformers >=5 wraps ``CLIPModel.get_image_features`` in
+   ``BaseModelOutputWithPooling`` instead of returning a tensor; the
+   helper ``_clip_image_features`` must unwrap to the projected feature
+   tensor (``pooler_output``).
+
+2. llava-onevision returns multi-patch ``pixel_values`` shaped
+   ``(B, P, C, H, W)``; ``VLMAdapter._prepare_vlm_inputs`` must accept
+   that without crashing on ``permute(1, 2, 0)`` of a 4D slice.
+
+Tests use stubs so they never download a model or touch HF.
+"""
+import torch
+import torch.nn as nn
+
+from pu.models.hf import VLMAdapter, _clip_image_features
+
+# ── (1) _clip_image_features unwrap ──────────────────────────────────────
+
+class _ClipModelStubTensor(nn.Module):
+    """Mimics transformers 4.x: get_image_features returns a Tensor."""
+
+    def __init__(self, B: int = 2, D: int = 512):
+        super().__init__()
+        self._B = B
+        self._D = D
+
+    def get_image_features(self, pixel_values):
+        return torch.randn(self._B, self._D)
+
+
+class _ClipModelStubBMOP(nn.Module):
+    """Mimics transformers >=5: returns BaseModelOutputWithPooling."""
+
+    def __init__(self, B: int = 2, D: int = 512):
+        super().__init__()
+        self._B = B
+        self._D = D
+
+    def get_image_features(self, pixel_values):
+        from transformers.modeling_outputs import BaseModelOutputWithPooling
+        return BaseModelOutputWithPooling(
+            last_hidden_state=torch.randn(self._B, 197, 768),
+            pooler_output=torch.randn(self._B, self._D),
+        )
+
+
+def test_clip_image_features_passthrough_when_already_tensor():
+    """transformers 4.x path — input already a tensor."""
+    m = _ClipModelStubTensor(B=3, D=512)
+    out = _clip_image_features(m, torch.randn(3, 3, 224, 224))
+    assert isinstance(out, torch.Tensor)
+    assert out.shape == (3, 512)
+
+
+def test_clip_image_features_unwraps_bmop():
+    """transformers >=5 path — picks pooler_output (the projected features)."""
+    m = _ClipModelStubBMOP(B=2, D=512)
+    out = _clip_image_features(m, torch.randn(2, 3, 224, 224))
+    assert isinstance(out, torch.Tensor)
+    assert out.shape == (2, 512), "should pick pooler_output, not last_hidden_state"
+
+
+def test_clip_image_features_raises_on_unrecognized():
+    """If the wrapper has no recognised tensor field, raise — don't return a
+    ModelOutput that would silently break callers downstream."""
+
+    class _Weird:
+        def get_image_features(self, pixel_values):
+            class _O:
+                pass
+            return _O()
+
+    import pytest
+    with pytest.raises(TypeError, match="recognizable image-feature tensor"):
+        _clip_image_features(_Weird(), torch.randn(1, 3, 224, 224))
+
+
+# ── (2) VLMAdapter._prepare_vlm_inputs handles 5D pixel_values ───────────
+
+class _StubProcessor:
+    """Returns the dict shape _prepare_vlm_inputs expects after re-encoding."""
+
+    def __call__(self, images, text, return_tensors=None, padding=None):
+        B = len(images)
+        return {
+            "input_ids":      torch.zeros(B, 5, dtype=torch.long),
+            "attention_mask": torch.ones(B, 5, dtype=torch.long),
+            "pixel_values":   torch.zeros(B, 3, 384, 384),
+        }
+
+
+def _make_stub_vlm(alias: str = "llava_ov_7b") -> VLMAdapter:
+    """Build a VLMAdapter without going through HF model loading."""
+    stub = VLMAdapter.__new__(VLMAdapter)
+    stub.alias = alias
+    stub.model = nn.Linear(4, 4)  # gives _prepare_vlm_inputs a device + dtype
+    stub.processor = _StubProcessor()
+    return stub
+
+
+def test_prepare_vlm_inputs_accepts_5d_multipatch():
+    """llava-onevision shape — was crashing on permute(1, 2, 0) of 4D slice."""
+    stub = _make_stub_vlm("llava_ov_7b")
+    pv = torch.randn(2, 5, 3, 384, 384)  # (B, P, C, H, W)
+    ids, pv_enc, attn = stub._prepare_vlm_inputs({"hsc": pv}, "hsc")
+    assert ids.shape == (2, 5)
+    assert pv_enc.shape == (2, 3, 384, 384)
+    assert attn.shape == (2, 5)
+
+
+def test_prepare_vlm_inputs_still_handles_4d():
+    """paligemma / llava-1.5 shape — the common case must not regress."""
+    stub = _make_stub_vlm("paligemma_3b")
+    pv = torch.randn(2, 3, 224, 224)
+    ids, pv_enc, attn = stub._prepare_vlm_inputs({"hsc": pv}, "hsc")
+    assert ids.shape == (2, 5)
+    assert pv_enc.shape == (2, 3, 384, 384)


### PR DESCRIPTION
## Summary

Two unrelated production bugs hit on cluster runs against the legacysurvey dataset:

### 1. CLIP fails on transformers 5.x with \`'BaseModelOutputWithPooling' object has no attribute 'float'\`

\`transformers >=5\` changed \`CLIPModel.get_image_features\` to return \`BaseModelOutputWithPooling\` instead of a \`Tensor\` (verified on transformers 5.5.4: \`type=BaseModelOutputWithPooling\`, \`pooler_output\` shape \`(B, 512)\` for clip-base, \`(B, 768)\` for clip-large). The CLIP path in \`HFAdapter.embed_for_mode\` and the visual-projection capture in \`HFAdapter.embed_all_layers_for_mode\` both call \`.float().detach()\` on the return value, which crashes.

Fix: new \`_clip_image_features\` helper that:
- passes through plain \`Tensor\` returns (transformers 4.x — unchanged behavior),
- unwraps \`BaseModelOutputWithPooling\` to \`pooler_output\` (the projected, text-aligned image features — same tensor 4.x used to return directly),
- raises \`TypeError\` if neither path matches (rather than silently returning a \`ModelOutput\` that would break downstream).

Both call sites in \`hf.py\` updated to use the helper.

### 2. \`llava-onevision\` crashes with \`permute(...): input.dim() = 4 is not equal to len(dims) = 3\`

\`llava-onevision\`'s processor returns multi-patch \`pixel_values\` shaped \`(B, P, C, H, W)\`, where \`P\` is the number of resolution tiles. \`VLMAdapter._prepare_vlm_inputs\` assumed \`(B, C, H, W)\` and called \`pv_cpu[i].permute(1, 2, 0)\` on what turned out to be a 4D slice.

Fix: detect 5D \`pixel_values\` and slice the canonical first patch before the PIL roundtrip. The processor in this method re-tiles from a single PIL image regardless, so downstream behavior on the model side is unchanged.

## What this unblocks

Without these fixes, every CLIP \`(base, large) × (legacysurvey, desi, sdss, jwst)\` job and every \`llava_ov_7b × dataset\` job fails before the extraction loop starts.

## Test plan

New \`tests/test_hf_clip_and_llava_ov.py\` covers both fixes with stubs (no model download, no HF access, runs in <1s):

- [x] \`test_clip_image_features_passthrough_when_already_tensor\` — transformers 4.x path is a no-op.
- [x] \`test_clip_image_features_unwraps_bmop\` — transformers 5.x \`BaseModelOutputWithPooling\` unwraps to \`pooler_output\` \`(B, 512)\` (not \`last_hidden_state\` which has the wrong shape).
- [x] \`test_clip_image_features_raises_on_unrecognized\` — guards against silently returning a non-tensor.
- [x] \`test_prepare_vlm_inputs_accepts_5d_multipatch\` — \`(B, P, C, H, W)\` from llava-onevision goes through cleanly.
- [x] \`test_prepare_vlm_inputs_still_handles_4d\` — paligemma / llava-1.5 4D shape still works.

Existing \`tests/test_vjepa_frame_expansion.py\` continues to pass (8/8 in the full new+existing run).

The fixes have already been deployed as monkeypatches in \`run_extraction.py\` on the cluster and verified to clear the affected job classes; this PR moves them into the package proper.