### PR TITLE
Curated cosmosweb additions: core helpers + isolated experiment scripts

### DIFF
--- a/experiments/cosmosweb/README.md
+++ b/experiments/cosmosweb/README.md
@@ -1,0 +1,51 @@
+# COSMOS-Web reproduction scripts
+
+Self-contained scripts to reproduce the COSMOS-Web physics-validation experiments
+on top of the `pu` package. These are not part of the installed package; they
+import from `pu` and run as standalone scripts.
+
+## Install
+
+From the repo root:
+
+```bash
+pip install -e ".[cosmosweb]"
+```
+
+This installs `pu` plus the extra dependencies the scripts here need
+(`scikit-learn`, `scipy`, `matplotlib`, `tqdm`).
+
+## What's here
+
+| File | Purpose |
+|---|---|
+| `run_intramodal.py` | Per-survey embedding + MKNN + linear-probe scaling |
+| `run_crossmodal.py` | HSC ↔ JWST cross-modal version of the same |
+| `probe_weight_analysis.py` | Inspect linear-probe weights on the embeddings |
+| `plot_mknn_vs_r2.py` | Plotting utility for MKNN-vs-$R^2$ scaling figures |
+| `test_linear_probe.py` | Minimal end-to-end test on convnext + cosmosweb |
+
+## Run
+
+```bash
+python experiments/cosmosweb/run_intramodal.py
+python experiments/cosmosweb/run_crossmodal.py
+```
+
+Both scripts write PDFs of figures and `.npy` cached embeddings to `embeddings/`.
+
+## Dataset
+
+The scripts pull from
+[`Ashodkh/cosmosweb-hsc-jwst-high-snr-pil2`](https://huggingface.co/datasets/Ashodkh/cosmosweb-hsc-jwst-high-snr-pil2)
+(set `HF_TOKEN` if private). The dataset adapter
+(`pu.pu_datasets.cosmosweb`) and the physics-probing utilities
+(`pu.metrics.physics`, `pu.metrics.neighbors.mknn_neighbor_input`) are part of
+the main `pu` package and are re-used by these scripts.
+
+## Notes
+
+- These scripts were originally contributed in PR #58 by @ashodkh. They have
+  been moved here, unchanged, so the main package stays small. The shared
+  utilities they rely on were merged into core.
+- Run on a GPU. CPU runs will be very slow.

--- a/experiments/cosmosweb/plot_mknn_vs_r2.py
+++ b/experiments/cosmosweb/plot_mknn_vs_r2.py
@@ -1,0 +1,406 @@
+#!/usr/bin/env python3
+"""
+Plot MKNN embedding similarity (mean MKNN vs every other model) against
+physics linear-probe R² (mean over stable Smith42/galaxies properties).
+
+One point per model. Tests the PRH prediction that models whose
+neighborhood structure is closer to the consensus also encode more physics.
+"""
+
+import argparse
+import sys
+from pathlib import Path
+
+import matplotlib
+matplotlib.use("Agg")
+import matplotlib.pyplot as plt
+import numpy as np
+import polars as pl
+from scipy.stats import pearsonr, spearmanr
+from sklearn.neighbors import NearestNeighbors
+from tqdm import tqdm
+
+ROOT = Path(__file__).resolve().parent.parent
+SCRIPTS_DIR = ROOT / "scripts"
+DATA_DIR = ROOT / "data"
+FIGS_DIR = ROOT / "figs"
+PHYSICS_DIR = DATA_DIR / "physics"
+
+sys.path.insert(0, str(SCRIPTS_DIR))
+from plot_r2_vs_params import (  # noqa: E402
+    EXCLUDE_PROPERTIES,
+    FAMILY_STYLE,
+    PARAM_COUNTS,
+)
+
+sys.path.insert(0, str(ROOT / "src"))
+from pu.metrics.physics import ALL_PROPERTIES, DEFAULT_PROPERTIES, linear_probe  # noqa: E402
+
+N_SUB = 10_000
+K_VALUES = (5, 10, 20)
+K_MAIN = 10
+SEED = 0
+
+MKNN_CACHE = DATA_DIR / "mknn_matrix.parquet"
+R2_CACHE = DATA_DIR / "physics_mean_r2.parquet"
+
+STABLE_PROPS = [p for p in DEFAULT_PROPERTIES if p not in EXCLUDE_PROPERTIES]
+
+
+def parse_filename(path: Path) -> tuple[str, str] | None:
+    stem = path.stem
+    if not stem.endswith("_test"):
+        return None
+    stem = stem[: -len("_test")]
+    family, _, size = stem.rpartition("_")
+    if not family or family not in PARAM_COUNTS:
+        return None
+    if size not in PARAM_COUNTS[family]:
+        return None
+    return family, size
+
+
+def discover_models() -> list[tuple[str, str, Path]]:
+    found: dict[tuple[str, str], Path] = {}
+    for p in sorted(PHYSICS_DIR.glob("*_test.parquet")):
+        parsed = parse_filename(p)
+        if parsed:
+            found[parsed] = p
+    ordered: list[tuple[str, str, Path]] = []
+    for family, sizes in PARAM_COUNTS.items():
+        for size in sizes:
+            if (family, size) in found:
+                ordered.append((family, size, found[(family, size)]))
+    return ordered
+
+
+def load_embeddings(family: str, size: str, path: Path) -> np.ndarray:
+    df = pl.read_parquet(path)
+    col = f"{family}_{size}_galaxies"
+    return np.stack(df[col].to_list()).astype(np.float32, copy=False)
+
+
+def unit_normalize(Z: np.ndarray) -> np.ndarray:
+    norms = np.linalg.norm(Z, axis=1, keepdims=True)
+    norms = np.where(norms < 1e-12, 1.0, norms)
+    return Z / norms
+
+
+def compute_knn_indices(Z: np.ndarray, k: int) -> np.ndarray:
+    # Cosine NN on Z == Euclidean NN on L2-normalised Z (same ordering),
+    # and the latter is markedly faster via BLAS.
+    Zn = unit_normalize(Z)
+    return (
+        NearestNeighbors(n_neighbors=k, metric="euclidean", algorithm="brute")
+        .fit(Zn)
+        .kneighbors(return_distance=False)
+    )
+
+
+def mknn_from_indices(nn1: np.ndarray, nn2: np.ndarray, k: int) -> float:
+    a = nn1[:, :k]
+    b = nn2[:, :k]
+    overlaps = np.fromiter(
+        (len(set(ai).intersection(bi)) for ai, bi in zip(a, b)),
+        dtype=np.int32,
+        count=a.shape[0],
+    )
+    return float(overlaps.mean() / k)
+
+
+def assert_aligned(models: list[tuple[str, str, Path]]) -> int:
+    lengths = {}
+    for family, size, path in models:
+        df = pl.read_parquet(path, columns=[f"{family}_{size}_galaxies"])
+        lengths[(family, size)] = df.height
+    n_unique = set(lengths.values())
+    if len(n_unique) != 1:
+        msg = "Parquets have different row counts:\n" + "\n".join(
+            f"  {fam}_{sz}: {n}" for (fam, sz), n in lengths.items()
+        )
+        raise RuntimeError(msg)
+    return n_unique.pop()
+
+
+def load_labels(n_samples: int) -> dict[str, np.ndarray]:
+    from datasets import load_dataset
+
+    ds = load_dataset(
+        "Smith42/galaxies", revision="v2.0", split="test", streaming=True,
+    )
+    keys = STABLE_PROPS
+    buckets: dict[str, list[float]] = {k: [] for k in keys}
+    for i, ex in enumerate(tqdm(ds, total=n_samples, desc="Streaming labels")):
+        if i >= n_samples:
+            break
+        for k in keys:
+            col = ALL_PROPERTIES.get(k, k)
+            v = ex.get(col)
+            buckets[k].append(float("nan") if v is None else float(v))
+
+    out: dict[str, np.ndarray] = {}
+    for k, vals in buckets.items():
+        if len(vals) != n_samples:
+            print(f"  warn: dropping {k} (got {len(vals)}, expected {n_samples})")
+            continue
+        arr = np.asarray(vals, dtype=np.float64)
+        if k in ("sfr", "ssfr"):
+            arr[arr <= -99] = np.nan
+        if np.any(np.isfinite(arr)):
+            out[k] = arr
+        else:
+            print(f"  warn: dropping {k} (all NaN)")
+    return out
+
+
+def compute_mknn_matrix(
+    models: list[tuple[str, str, Path]],
+    idx: np.ndarray,
+) -> dict[int, np.ndarray]:
+    """Compute symmetric MKNN matrices for each k in K_VALUES.
+
+    We fit kNN once per model at k_max = max(K_VALUES) and slice for smaller k.
+    """
+    k_max = max(K_VALUES)
+    print(f"Computing kNN (k={k_max}) for {len(models)} models on {idx.size} samples")
+    nn_indices: list[np.ndarray] = []
+    for family, size, path in tqdm(models, desc="kNN per model"):
+        Z = load_embeddings(family, size, path)[idx]
+        nn_indices.append(compute_knn_indices(Z, k_max))
+
+    M = len(models)
+    mats = {k: np.full((M, M), np.nan, dtype=np.float64) for k in K_VALUES}
+    pairs = [(i, j) for i in range(M) for j in range(i + 1, M)]
+    print(f"Computing MKNN over {len(pairs)} model pairs")
+    for i, j in tqdm(pairs, desc="Pairwise MKNN"):
+        for k in K_VALUES:
+            v = mknn_from_indices(nn_indices[i], nn_indices[j], k)
+            mats[k][i, j] = v
+            mats[k][j, i] = v
+    return mats
+
+
+def mknn_matrix_to_df(
+    mats: dict[int, np.ndarray], labels: list[str]
+) -> pl.DataFrame:
+    rows = []
+    M = len(labels)
+    for k, mat in mats.items():
+        for i in range(M):
+            for j in range(M):
+                if i == j:
+                    continue
+                rows.append({"k": k, "model_i": labels[i], "model_j": labels[j],
+                             "mknn": mat[i, j]})
+    return pl.DataFrame(rows)
+
+
+def df_to_mknn_matrix(df: pl.DataFrame, labels: list[str]) -> dict[int, np.ndarray]:
+    label_to_idx = {lab: i for i, lab in enumerate(labels)}
+    M = len(labels)
+    mats: dict[int, np.ndarray] = {}
+    for k in sorted(df["k"].unique().to_list()):
+        sub = df.filter(pl.col("k") == k)
+        mat = np.full((M, M), np.nan, dtype=np.float64)
+        for row in sub.iter_rows(named=True):
+            i = label_to_idx.get(row["model_i"])
+            j = label_to_idx.get(row["model_j"])
+            if i is None or j is None:
+                continue
+            mat[i, j] = row["mknn"]
+        mats[int(k)] = mat
+    return mats
+
+
+def compute_mean_r2(
+    models: list[tuple[str, str, Path]],
+    idx: np.ndarray,
+    labels_full: dict[str, np.ndarray],
+) -> pl.DataFrame:
+    labels = {k: v[idx] for k, v in labels_full.items()}
+    rows = []
+    for family, size, path in tqdm(models, desc="Linear probes"):
+        Z = load_embeddings(family, size, path)[idx]
+        r2s: list[float] = []
+        per_prop: dict[str, float] = {}
+        for prop in STABLE_PROPS:
+            if prop not in labels:
+                continue
+            res = linear_probe(Z, labels[prop], cv=5)
+            if isinstance(res, dict):
+                r2 = res["mean"]
+            else:
+                r2 = float(res)
+            if np.isfinite(r2):
+                r2s.append(r2)
+                per_prop[prop] = r2
+        mean_r2 = float(np.mean(r2s)) if r2s else float("nan")
+        row = {"family": family, "size": size, "mean_r2": mean_r2, "n_props": len(r2s)}
+        row.update({f"r2_{p}": v for p, v in per_prop.items()})
+        rows.append(row)
+        print(f"  {family:<10} {size:<12} mean R² = {mean_r2:.4f} over {len(r2s)} props")
+    return pl.DataFrame(rows)
+
+
+def plot_scatter(
+    ax,
+    x: np.ndarray,
+    y: np.ndarray,
+    families: list[str],
+    sizes: list[str],
+    title: str,
+) -> None:
+    for family in PARAM_COUNTS:
+        mask = np.array([f == family for f in families])
+        if not mask.any():
+            continue
+        style = FAMILY_STYLE[family]
+        ax.scatter(
+            x[mask], y[mask],
+            color=style["color"], marker=style["marker"],
+            s=70, label=style["label"], edgecolors="black", linewidths=0.4,
+        )
+        for xi, yi, sz in zip(x[mask], y[mask], np.array(sizes)[mask]):
+            ax.annotate(
+                sz, (xi, yi), xytext=(4, 2), textcoords="offset points",
+                fontsize=6, color=style["color"],
+            )
+
+    finite = np.isfinite(x) & np.isfinite(y)
+    if finite.sum() >= 3:
+        rho, p_rho = spearmanr(x[finite], y[finite])
+        r, p_r = pearsonr(x[finite], y[finite])
+        ax.text(
+            0.02, 0.98,
+            f"Spearman ρ = {rho:.3f}  (p = {p_rho:.2g})\n"
+            f"Pearson  r = {r:.3f}  (p = {p_r:.2g})\n"
+            f"n = {int(finite.sum())} models",
+            transform=ax.transAxes, va="top", ha="left", fontsize=9,
+            bbox=dict(boxstyle="round,pad=0.3", fc="white", ec="0.7", alpha=0.9),
+        )
+
+    ax.set_xlabel("Mean MKNN to other models (cosine, k=%d)" %
+                  (K_MAIN if title is None else K_MAIN), fontsize=11)
+    ax.set_ylabel("Mean $R^2$ (linear probe)", fontsize=11)
+    ax.set_title(title, fontsize=11)
+
+
+def make_main_figure(
+    mknn_mat: np.ndarray,
+    r2_df: pl.DataFrame,
+    families: list[str],
+    sizes: list[str],
+) -> None:
+    x = np.nanmean(mknn_mat, axis=1)
+    y = r2_df["mean_r2"].to_numpy()
+    fig, ax = plt.subplots(figsize=(9, 6))
+    plot_scatter(
+        ax, x, y, families, sizes,
+        title=f"Representational convergence vs physics R² "
+              f"(MKNN k={K_MAIN}, N={N_SUB} galaxies)",
+    )
+    ax.legend(fontsize=9, loc="lower right", ncol=2)
+    fig.tight_layout()
+    out = FIGS_DIR / "mknn_vs_r2.pdf"
+    fig.savefig(out, dpi=150, bbox_inches="tight")
+    print(f"Saved {out}")
+    plt.close(fig)
+
+
+def make_sensitivity_figure(
+    mats: dict[int, np.ndarray],
+    r2_df: pl.DataFrame,
+    families: list[str],
+    sizes: list[str],
+) -> None:
+    ks = sorted(mats.keys())
+    fig, axes = plt.subplots(1, len(ks), figsize=(6 * len(ks), 5), sharey=True)
+    if len(ks) == 1:
+        axes = [axes]
+    y = r2_df["mean_r2"].to_numpy()
+    for ax, k in zip(axes, ks):
+        x = np.nanmean(mats[k], axis=1)
+        plot_scatter(ax, x, y, families, sizes, title=f"k = {k}")
+        ax.set_xlabel(f"Mean MKNN to other models (cosine, k={k})", fontsize=10)
+    axes[0].legend(fontsize=8, loc="lower right", ncol=2)
+    fig.suptitle("MKNN-vs-R² sensitivity to k", fontsize=13)
+    fig.tight_layout()
+    out = FIGS_DIR / "mknn_vs_r2_k_sensitivity.pdf"
+    fig.savefig(out, dpi=150, bbox_inches="tight")
+    print(f"Saved {out}")
+    plt.close(fig)
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--check-alignment", action="store_true",
+                        help="Only verify all parquets have the same row count and exit")
+    parser.add_argument("--n-sub", type=int, default=N_SUB,
+                        help="Number of galaxies to subsample for MKNN and probes")
+    parser.add_argument("--recompute", action="store_true",
+                        help="Ignore caches and recompute everything")
+    args = parser.parse_args()
+
+    FIGS_DIR.mkdir(exist_ok=True)
+    DATA_DIR.mkdir(exist_ok=True)
+
+    models = discover_models()
+    if not models:
+        raise RuntimeError(f"No physics parquets found under {PHYSICS_DIR}")
+    print(f"Discovered {len(models)} models under {PHYSICS_DIR}:")
+    for family, size, path in models:
+        print(f"  {family}_{size}  ({path.name})")
+
+    n_full = assert_aligned(models)
+    print(f"\nAll parquets aligned at {n_full} rows.")
+    if args.check_alignment:
+        return
+
+    n_sub = min(args.n_sub, n_full)
+    rng = np.random.default_rng(SEED)
+    idx = np.sort(rng.choice(n_full, size=n_sub, replace=False))
+    print(f"Subsampling {n_sub} rows (seed={SEED}).")
+
+    labels = [f"{f}_{s}" for f, s, _ in models]
+    families = [f for f, _, _ in models]
+    sizes = [s for _, s, _ in models]
+
+    if MKNN_CACHE.exists() and not args.recompute:
+        print(f"Loading cached MKNN matrix from {MKNN_CACHE}")
+        mats = df_to_mknn_matrix(pl.read_parquet(MKNN_CACHE), labels)
+        missing_ks = [k for k in K_VALUES if k not in mats]
+        if missing_ks:
+            print(f"Cache missing k={missing_ks}, recomputing")
+            mats = compute_mknn_matrix(models, idx)
+            mknn_matrix_to_df(mats, labels).write_parquet(MKNN_CACHE)
+    else:
+        mats = compute_mknn_matrix(models, idx)
+        mknn_matrix_to_df(mats, labels).write_parquet(MKNN_CACHE)
+        print(f"Saved MKNN matrix to {MKNN_CACHE}")
+
+    if R2_CACHE.exists() and not args.recompute:
+        print(f"Loading cached R² table from {R2_CACHE}")
+        r2_df = pl.read_parquet(R2_CACHE)
+        cached_keys = {(r["family"], r["size"]) for r in r2_df.iter_rows(named=True)}
+        needed_keys = {(f, s) for f, s, _ in models}
+        if cached_keys != needed_keys:
+            print("Cache model set differs from discovered; recomputing R²")
+            labels_full = load_labels(n_full)
+            r2_df = compute_mean_r2(models, idx, labels_full)
+            r2_df.write_parquet(R2_CACHE)
+    else:
+        labels_full = load_labels(n_full)
+        r2_df = compute_mean_r2(models, idx, labels_full)
+        r2_df.write_parquet(R2_CACHE)
+        print(f"Saved R² table to {R2_CACHE}")
+
+    # Align r2_df row order with `models`
+    key_to_row = {(r["family"], r["size"]): r for r in r2_df.iter_rows(named=True)}
+    r2_df = pl.DataFrame([key_to_row[(f, s)] for f, s, _ in models])
+
+    make_main_figure(mats[K_MAIN], r2_df, families, sizes)
+    make_sensitivity_figure(mats, r2_df, families, sizes)
+
+
+if __name__ == "__main__":
+    main()

--- a/experiments/cosmosweb/probe_weight_analysis.py
+++ b/experiments/cosmosweb/probe_weight_analysis.py
@@ -1,0 +1,638 @@
+"""
+Probe weight analysis: cosine similarity within models, Procrustes disparity across pairs.
+
+For each telescope × model × size:
+  - Fits one linear probe per property (redshift, mass, sSFR); seed=42, 5000 test objects.
+  - Computes the 3×3 cosine-similarity matrix of the probe weight vectors.
+
+Cross-model (per telescope):
+  - For each property, computes pairwise Procrustes disparity of test predictions
+    across all model pairs, then plots a histogram.
+"""
+
+import os
+import pickle
+from itertools import combinations
+
+import matplotlib.pyplot as plt
+import numpy as np
+from datasets import load_dataset
+from matplotlib.backends.backend_pdf import PdfPages
+from matplotlib.lines import Line2D
+from scipy.spatial import procrustes as scipy_procrustes
+from sklearn.linear_model import LinearRegression
+from sklearn.metrics import r2_score
+from sklearn.model_selection import train_test_split
+from sklearn.preprocessing import StandardScaler
+from tqdm import tqdm
+
+from pu.pu_datasets.cosmosweb import CATALOG_COLUMNS
+
+# ── Config ──────────────────────────────────────────────────────────────────────
+DATASET         = ""
+OUT_DIR         = ""
+EMB_DIR         = f"{OUT_DIR}/embeddings"
+DS_TAG          = DATASET.split("/")[-1]
+N_USE           = 45000
+UPSAMPLE_SUFFIX = "_upsampled"
+PROBE_TEST_SIZE = 5000
+SEED            = 42
+TELESCOPES      = ["hsc", "jwst"]
+TARGET_PROPS    = ["redshift", "mass", "sSFR"]
+
+model_map = {
+    "vit":       ["base", "large", "huge"],
+    "clip":      ["base", "large"],
+    "dinov3":    ["vits16", "vits16plus", "vitb16", "vitl16", "vith16plus", "vit7b16"],
+    "convnext":  ["nano", "tiny", "base", "large"],
+    "ijepa":     ["huge", "giant"],
+    "vjepa":     ["large", "huge", "giant"],
+    "astropt":   ["015M", "095M", "850M"],
+    "vit-mae":   ["base", "large", "huge"],
+    "paligemma": ["3b", "10b", "28b"],
+    "llava_15":  ["7b", "13b"],
+}
+
+
+# ── 1. Catalog ──────────────────────────────────────────────────────────────────
+print(f"Streaming catalog from {DATASET} ({N_USE} galaxies)…")
+ds_raw = load_dataset(DATASET, split="train", streaming=True)
+
+raw = {k: [] for k in CATALOG_COLUMNS}
+for row in tqdm(ds_raw, total=N_USE, desc="Catalog"):
+    for param, col in CATALOG_COLUMNS.items():
+        raw[param].append(row[col])
+    if len(raw["redshift"]) >= N_USE:
+        break
+
+all_params = {k: np.array(v, dtype=np.float32) for k, v in raw.items()}
+n_valid = len(all_params["redshift"])
+print(f"Loaded {n_valid} galaxies.")
+
+
+# ── 2. Clip targets & build consistent train/test split ─────────────────────────
+props_clipped = {}
+for prop in TARGET_PROPS:
+    v = all_params[prop]
+    finite = np.isfinite(v)
+    lo, hi = np.quantile(v[finite], [0.01, 0.99])
+    vc = np.clip(v, lo, hi).astype(np.float32)
+    vc[~finite] = np.nan
+    props_clipped[prop] = vc
+
+all_valid = np.stack(
+    [np.isfinite(props_clipped[p]) for p in TARGET_PROPS], axis=1
+).all(axis=1)
+valid_indices = np.where(all_valid)[0]
+print(f"Rows with all 3 props finite: {len(valid_indices)}")
+
+idx_train, idx_test = train_test_split(
+    valid_indices, test_size=PROBE_TEST_SIZE, random_state=SEED
+)
+y_test = {prop: props_clipped[prop][idx_test] for prop in TARGET_PROPS}
+
+
+# ── 3. Helpers ──────────────────────────────────────────────────────────────────
+def emb_path(telescope, alias, size):
+    return (
+        f"{EMB_DIR}/{telescope}_embeddings_{DS_TAG}"
+        f"_{alias}_{size}_{n_valid}{UPSAMPLE_SUFFIX}.npy"
+    )
+
+
+CACHE_DIR = f"{OUT_DIR}/probe_weight_cache_{n_valid}{UPSAMPLE_SUFFIX}"
+os.makedirs(CACHE_DIR, exist_ok=True)
+
+
+def probe_cache_path(telescope, alias, size):
+    return f"{CACHE_DIR}/{telescope}_{alias}_{size}.pkl"
+
+
+def run_probes(telescope, alias, size):
+    """Load embeddings, fit one linear probe per property, return results dict."""
+    cache = probe_cache_path(telescope, alias, size)
+    if os.path.exists(cache):
+        with open(cache, "rb") as f:
+            return pickle.load(f)
+
+    path = emb_path(telescope, alias, size)
+    if not os.path.exists(path):
+        return None
+
+    emb = np.load(path)
+    scaler = StandardScaler()
+    X_train = scaler.fit_transform(emb[idx_train])
+    X_test  = scaler.transform(emb[idx_test])
+
+    result = {}
+    for prop in TARGET_PROPS:
+        y = props_clipped[prop]
+        reg = LinearRegression().fit(X_train, y[idx_train])
+        pred = reg.predict(X_test)
+        result[prop] = {
+            "w":    reg.coef_.astype(np.float32),   # shape (d,)
+            "pred": pred.astype(np.float32),          # shape (n_test,)
+            "r2":   float(r2_score(y[idx_test], pred)),
+        }
+
+    with open(cache, "wb") as f:
+        pickle.dump(result, f)
+    return result
+
+
+# ── 4. Run probes for all models ────────────────────────────────────────────────
+all_results = {}  # (telescope, alias, size) → probe dict
+
+for telescope in TELESCOPES:
+    print(f"\n{'─'*60}  {telescope.upper()}")
+    for alias, sizes in model_map.items():
+        for size in sizes:
+            res = run_probes(telescope, alias, size)
+            if res is None:
+                continue
+            key = (telescope, alias, size)
+            all_results[key] = res
+            r2_str = "  ".join(f"{p}={res[p]['r2']:.3f}" for p in TARGET_PROPS)
+            print(f"  {alias:12s} {size:12s}  {r2_str}")
+
+
+# ── 5. Cosine similarity between probe weight vectors (within each model) ────────
+# For each model, W is (3, d); cosine_mats[key] is the (3, 3) Gram matrix.
+cosine_mats = {}
+
+for key, res in all_results.items():
+    W = np.stack([res[p]["w"] for p in TARGET_PROPS], axis=0)   # (3, d)
+    norms = np.linalg.norm(W, axis=1, keepdims=True).clip(min=1e-12)
+    W_norm = W / norms
+    cosine_mats[key] = (W_norm @ W_norm.T).clip(-1, 1)           # (3, 3)
+
+
+# ── 6. Procrustes disparity — compute once for all model pairs ───────────────────
+# Covers within-telescope and cross-telescope (HSC↔JWST same model) pairs.
+# pred vectors are (n_test, 1) and share the same row indices, so comparison is valid.
+MODEL_PARAMS = {
+    ("vit",       "base"):        86e6,
+    ("vit",       "large"):      307e6,
+    ("vit",       "huge"):       632e6,
+    ("clip",      "base"):        86e6,
+    ("clip",      "large"):      307e6,
+    ("dinov3",    "vits16"):      21e6,
+    ("dinov3",    "vits16plus"):  22e6,
+    ("dinov3",    "vitb16"):      86e6,
+    ("dinov3",    "vitl16"):     307e6,
+    ("dinov3",    "vith16plus"): 650e6,
+    ("dinov3",    "vit7b16"):   7000e6,
+    ("convnext",  "nano"):        15e6,
+    ("convnext",  "tiny"):        28e6,
+    ("convnext",  "base"):        89e6,
+    ("convnext",  "large"):      198e6,
+    ("ijepa",     "huge"):       632e6,
+    ("ijepa",     "giant"):     1100e6,
+    ("vjepa",     "large"):      307e6,
+    ("vjepa",     "huge"):       632e6,
+    ("vjepa",     "giant"):     1100e6,
+    ("astropt",   "015M"):        15e6,
+    ("astropt",   "095M"):        95e6,
+    ("astropt",   "850M"):       850e6,
+    ("vit-mae",   "base"):        86e6,
+    ("vit-mae",   "large"):      307e6,
+    ("vit-mae",   "huge"):       632e6,
+    ("paligemma", "3b"):        3000e6,
+    ("paligemma", "10b"):      10000e6,
+    ("paligemma", "28b"):      28000e6,
+    ("llava_15",  "7b"):        7000e6,
+    ("llava_15",  "13b"):      13000e6,
+}
+
+all_keys = list(all_results.keys())
+all_pairs = list(combinations(all_keys, 2))
+
+PROC_CACHE_PATH = f"{CACHE_DIR}/proc_cache.pkl"
+
+if os.path.exists(PROC_CACHE_PATH):
+    print(f"Loading Procrustes cache from {PROC_CACHE_PATH}…")
+    with open(PROC_CACHE_PATH, "rb") as f:
+        proc_cache = pickle.load(f)
+else:
+    proc_cache = {}  # (ki, kj, prop) → disparity; stored symmetrically for easy lookup
+    for ki, kj in tqdm(all_pairs, desc="Procrustes (all pairs)"):
+        for prop in TARGET_PROPS:
+            pred_i = all_results[ki][prop]["pred"].reshape(-1, 1).astype(float)
+            pred_j = all_results[kj][prop]["pred"].reshape(-1, 1).astype(float)
+            try:
+                _, _, disp = scipy_procrustes(pred_i, pred_j)
+            except Exception:
+                disp = np.nan
+            proc_cache[(ki, kj, prop)] = disp
+            proc_cache[(kj, ki, prop)] = disp  # symmetric
+    with open(PROC_CACHE_PATH, "wb") as f:
+        pickle.dump(proc_cache, f)
+    print(f"Saved Procrustes cache → {PROC_CACHE_PATH}")
+
+# ── 6a. Within-telescope cross-model distribution (for histogram) ────────────────
+proc_disp = {tel: {prop: [] for prop in TARGET_PROPS} for tel in TELESCOPES}
+for (ki, kj, prop), disp in proc_cache.items():
+    if ki[0] == kj[0] and ki < kj:  # same telescope, count each pair once
+        proc_disp[ki[0]][prop].append(disp)
+
+# ── 6b. Intra-modal adjacent-size Procrustes (lookup from cache) ─────────────────
+adj_disp = {tel: {} for tel in TELESCOPES}
+for telescope in TELESCOPES:
+    for alias, sizes in model_map.items():
+        alias_data = {prop: [] for prop in TARGET_PROPS}
+        for s1, s2 in zip(sizes[:-1], sizes[1:]):
+            k1 = (telescope, alias, s1)
+            k2 = (telescope, alias, s2)
+            if k1 not in all_results or k2 not in all_results:
+                continue
+            pair_label = f"{s1}→{s2}"
+            for prop in TARGET_PROPS:
+                alias_data[prop].append((pair_label, proc_cache[(k1, k2, prop)]))
+        if any(alias_data[p] for p in TARGET_PROPS):
+            adj_disp[telescope][alias] = alias_data
+
+# ── 6c. Cross-modal (HSC vs JWST) Procrustes per model (lookup from cache) ───────
+cross_modal_disp = {prop: [] for prop in TARGET_PROPS}
+for alias, sizes in model_map.items():
+    for size in sizes:
+        k_hsc  = ("hsc",  alias, size)
+        k_jwst = ("jwst", alias, size)
+        if k_hsc not in all_results or k_jwst not in all_results:
+            continue
+        n_params = MODEL_PARAMS.get((alias, size), np.nan)
+        for prop in TARGET_PROPS:
+            cross_modal_disp[prop].append(
+                (alias, size, n_params, proc_cache[(k_hsc, k_jwst, prop)])
+            )
+
+
+# ── 7. Plots ────────────────────────────────────────────────────────────────────
+PROP_LABEL  = {"redshift": "z", "mass": "M★", "sSFR": "sSFR"}
+PROP_COLOR  = {"redshift": "#2196F3", "mass": "#4CAF50", "sSFR": "#FF5722"}
+TEL_COLOR   = {"hsc": "steelblue", "jwst": "tomato"}
+_palette    = plt.rcParams["axes.prop_cycle"].by_key()["color"]
+ALIAS_COLOR = {alias: _palette[i % len(_palette)] for i, alias in enumerate(model_map)}
+
+PDF_VARIANTS = [
+    ("all",    set(model_map)),
+    ("nodinov3", set(model_map) - {"dinov3"}),
+]
+
+for variant_tag, active_aliases in PDF_VARIANTS:
+    pdf_path = (
+        f"{OUT_DIR}/probe_weight_analysis_{n_valid}galaxies"
+        f"{UPSAMPLE_SUFFIX}_{variant_tag}.pdf"
+    )
+
+    # Re-derive proc_disp restricted to this variant's aliases.
+    v_proc_disp = {tel: {prop: [] for prop in TARGET_PROPS} for tel in TELESCOPES}
+    for (ki, kj, prop), disp in proc_cache.items():
+        if ki[0] == kj[0] and ki < kj and ki[1] in active_aliases and kj[1] in active_aliases:
+            v_proc_disp[ki[0]][prop].append(disp)
+
+    with PdfPages(pdf_path) as pdf:
+
+        # ── 7a: cosine-similarity heatmaps (one page per telescope) ─────────────
+        for telescope in TELESCOPES:
+            tel_keys = sorted(
+                [k for k in all_results if k[0] == telescope and k[1] in active_aliases],
+                key=lambda k: (k[1], k[2]),
+            )
+            n = len(tel_keys)
+            if n == 0:
+                continue
+
+            ncols = min(6, n)
+            nrows = (n + ncols - 1) // ncols
+
+            fig, axes = plt.subplots(
+                nrows, ncols,
+                figsize=(ncols * 2.5, nrows * 2.5 + 0.7),
+                squeeze=False,
+            )
+            fig.suptitle(
+                f"Cosine similarity between probe weight vectors — {telescope.upper()}\n"
+                f"Axes: {' / '.join(PROP_LABEL[p] for p in TARGET_PROPS)}",
+                fontsize=12,
+            )
+
+            last_im = None
+            lbls = [PROP_LABEL[p] for p in TARGET_PROPS]
+            for idx, key in enumerate(tel_keys):
+                r, c = divmod(idx, ncols)
+                ax = axes[r][c]
+                mat = cosine_mats[key]
+                last_im = ax.imshow(mat, vmin=-1, vmax=1, cmap="RdBu_r", aspect="equal")
+                ax.set_xticks(range(3))
+                ax.set_yticks(range(3))
+                ax.set_xticklabels(lbls, fontsize=6, rotation=45)
+                ax.set_yticklabels(lbls, fontsize=6)
+                ax.set_title(f"{key[1]}\n{key[2]}", fontsize=7)
+                for i in range(3):
+                    for j in range(3):
+                        val = mat[i, j]
+                        fc = "white" if abs(val) > 0.75 else "black"
+                        ax.text(j, i, f"{val:.2f}", ha="center", va="center",
+                                fontsize=5.5, color=fc)
+
+            for idx in range(n, nrows * ncols):
+                r, c = divmod(idx, ncols)
+                axes[r][c].set_visible(False)
+
+            if last_im is not None:
+                fig.colorbar(
+                    last_im, ax=axes.flatten().tolist(),
+                    fraction=0.015, pad=0.04, label="cosine similarity",
+                )
+            fig.tight_layout()
+            pdf.savefig(fig)
+            plt.close(fig)
+
+        # ── 7b: Procrustes disparity histograms (one panel per property) ─────────
+        fig, axes = plt.subplots(1, len(TARGET_PROPS), figsize=(5 * len(TARGET_PROPS), 4.5))
+        fig.suptitle(
+            f"Procrustes disparity of test predictions across model pairs\n"
+            f"(n_test={PROBE_TEST_SIZE}, seed={SEED}; each count = one model pair)",
+            fontsize=12,
+        )
+        for ax, prop in zip(axes, TARGET_PROPS):
+            for telescope in TELESCOPES:
+                d = [x for x in v_proc_disp[telescope][prop] if np.isfinite(x)]
+                if d:
+                    ax.hist(
+                        d, bins=40, alpha=0.6,
+                        color=TEL_COLOR[telescope],
+                        label=f"{telescope.upper()} (n={len(d)} pairs)",
+                    )
+            ax.set_xlabel("Procrustes disparity", fontsize=11)
+            ax.set_ylabel("Number of model pairs", fontsize=11)
+            ax.set_title(prop, fontsize=12)
+            ax.legend(fontsize=9)
+            ax.grid(True, alpha=0.3)
+        fig.tight_layout()
+        pdf.savefig(fig)
+        plt.close(fig)
+
+        # ── 7c: R² overview (one bar chart per telescope) ────────────────────────
+        for telescope in TELESCOPES:
+            tel_keys = [k for k in all_results
+                        if k[0] == telescope and k[1] in active_aliases]
+            if not tel_keys:
+                continue
+
+            labels = [f"{k[1]}\n{k[2]}" for k in tel_keys]
+            x = np.arange(len(tel_keys))
+            width = 0.25
+
+            fig, ax = plt.subplots(figsize=(max(10, len(tel_keys) * 0.65), 4.5))
+            for i, prop in enumerate(TARGET_PROPS):
+                r2s = [all_results[k][prop]["r2"] for k in tel_keys]
+                ax.bar(x + i * width, r2s, width, label=prop,
+                       color=PROP_COLOR[prop], alpha=0.85)
+
+            ax.set_xticks(x + width)
+            ax.set_xticklabels(labels, rotation=45, ha="right", fontsize=6)
+            ax.set_ylabel("R²", fontsize=11)
+            ax.set_title(
+                f"Linear probe R² — {telescope.upper()} (seed={SEED}, n_test={PROBE_TEST_SIZE})",
+                fontsize=11,
+            )
+            ax.legend(fontsize=9)
+            ax.grid(axis="y", alpha=0.3)
+            ax.axhline(0, color="k", lw=0.5)
+            fig.tight_layout()
+            pdf.savefig(fig)
+            plt.close(fig)
+
+        # ── 7d: Intra-modal adjacent-size Procrustes disparity ──────────────────
+        for telescope in TELESCOPES:
+            fig, axes = plt.subplots(
+                1, len(TARGET_PROPS),
+                figsize=(5.5 * len(TARGET_PROPS), 4.5),
+                squeeze=False,
+            )
+            fig.suptitle(
+                f"Intra-modal Procrustes disparity (adjacent sizes) — {telescope.upper()}",
+                fontsize=12,
+            )
+            for col, prop in enumerate(TARGET_PROPS):
+                ax = axes[0][col]
+                for alias in (a for a in model_map if a in active_aliases):
+                    alias_data = adj_disp.get(telescope, {}).get(alias)
+                    if not alias_data or not alias_data[prop]:
+                        continue
+                    pair_labels = [lbl for lbl, _ in alias_data[prop]]
+                    yvals       = [d   for _, d   in alias_data[prop]]
+                    ax.plot(range(len(pair_labels)), yvals, marker="o",
+                            color=ALIAS_COLOR[alias], label=alias)
+                    ax.set_xticks(range(len(pair_labels)))
+                    ax.set_xticklabels(pair_labels, rotation=15, ha="right", fontsize=8)
+                ax.set_ylabel("Procrustes disparity", fontsize=10)
+                ax.set_xlabel("Adjacent size pair", fontsize=10)
+                ax.set_title(PROP_LABEL[prop], fontsize=11)
+                ax.legend(fontsize=7, ncol=2)
+                ax.grid(True, alpha=0.3)
+            fig.tight_layout()
+            pdf.savefig(fig)
+            plt.close(fig)
+
+        # ── 7e: Cross-modal Procrustes disparity vs number of model parameters ───
+        fig, axes = plt.subplots(1, len(TARGET_PROPS), figsize=(5 * len(TARGET_PROPS), 4.5))
+        if len(TARGET_PROPS) == 1:
+            axes = [axes]
+        fig.suptitle(
+            "Cross-modal Procrustes disparity (HSC vs JWST) vs model size",
+            fontsize=12,
+        )
+        for ax, prop in zip(axes, TARGET_PROPS):
+            entries = [
+                (alias, size, np_, disp)
+                for alias, size, np_, disp in cross_modal_disp[prop]
+                if alias in active_aliases and np.isfinite(np_) and np.isfinite(disp)
+            ]
+            if not entries:
+                ax.set_title(prop)
+                continue
+            xs     = [e[2] for e in entries]
+            ys     = [e[3] for e in entries]
+            labels = [f"{e[0]}\n{e[1]}" for e in entries]
+            ax.scatter(xs, ys, alpha=0.85, zorder=3)
+            for xi, yi, lbl in zip(xs, ys, labels):
+                ax.annotate(lbl, (xi, yi), fontsize=5.5,
+                            ha="left", va="bottom",
+                            xytext=(3, 3), textcoords="offset points")
+            ax.set_xscale("log")
+            ax.set_xlabel("Number of parameters", fontsize=11)
+            ax.set_ylabel("Procrustes disparity", fontsize=11)
+            ax.set_title(prop, fontsize=12)
+            ax.grid(True, alpha=0.3)
+        fig.tight_layout()
+        pdf.savefig(fig)
+        plt.close(fig)
+
+        # ── 7f: Probe weight cosine similarity vs number of model parameters ─────
+        PAIR_INFO = [
+            (0, 1, f"{PROP_LABEL['redshift']} vs {PROP_LABEL['mass']}",   "#2196F3"),
+            (0, 2, f"{PROP_LABEL['redshift']} vs {PROP_LABEL['sSFR']}",   "#FF5722"),
+            (1, 2, f"{PROP_LABEL['mass']} vs {PROP_LABEL['sSFR']}",       "#4CAF50"),
+        ]
+        TEL_MARKERS = {"hsc": "o", "jwst": "^"}
+
+        fig, ax = plt.subplots(figsize=(8, 5))
+        for pi, pj, pair_label, color in PAIR_INFO:
+            for telescope in TELESCOPES:
+                xs, ys = [], []
+                for key in all_results:
+                    tel, alias, size = key
+                    if tel != telescope or alias not in active_aliases:
+                        continue
+                    n_params = MODEL_PARAMS.get((alias, size), np.nan)
+                    if not np.isfinite(n_params):
+                        continue
+                    xs.append(n_params)
+                    ys.append(float(cosine_mats[key][pi, pj]))
+                ax.scatter(xs, ys, color=color, marker=TEL_MARKERS[telescope],
+                           alpha=0.75, zorder=3, s=40)
+
+        ax.set_xscale("log")
+        ax.set_ylim(-1, 1)
+        ax.axhline(0, color="k", lw=0.6, ls="--", alpha=0.5)
+        ax.set_xlabel("Number of parameters", fontsize=11)
+        ax.set_ylabel("Cosine similarity", fontsize=11)
+        ax.set_title(
+            "Probe weight vector cosine similarity vs model size",
+            fontsize=12,
+        )
+        ax.grid(True, alpha=0.3)
+
+        pair_handles = [
+            Line2D([0], [0], marker="o", color="w", markerfacecolor=color,
+                   markersize=8, label=pair_label)
+            for _, _, pair_label, color in PAIR_INFO
+        ]
+        tel_handles = [
+            Line2D([0], [0], marker=TEL_MARKERS[tel], color="gray",
+                   markerfacecolor="gray", markersize=8, linestyle="None",
+                   label=tel.upper())
+            for tel in TELESCOPES
+        ]
+        ax.legend(handles=pair_handles + tel_handles, fontsize=8, ncol=2)
+        fig.tight_layout()
+        pdf.savefig(fig)
+        plt.close(fig)
+
+        # ── 7g: Per-telescope averaged cosine-similarity matrix + pair histograms ─
+        bins = np.linspace(-1, 1, 101)
+        for telescope in TELESCOPES:
+            tel_keys = [
+                k for k in all_results
+                if k[0] == telescope and k[1] in active_aliases
+            ]
+            if not tel_keys:
+                continue
+
+            mats = np.stack([cosine_mats[k] for k in tel_keys], axis=0)  # (N, 3, 3)
+            avg_mat = mats.mean(axis=0)
+
+            fig, (ax_heat, ax_hist) = plt.subplots(1, 2, figsize=(10, 4.5))
+            fig.suptitle(
+                f"Probe weight cosine similarity — {telescope.upper()} "
+                f"(avg over {len(tel_keys)} models)",
+                fontsize=12,
+            )
+
+            lbls = [PROP_LABEL[p] for p in TARGET_PROPS]
+            im = ax_heat.imshow(avg_mat, vmin=-1, vmax=1, cmap="RdBu_r", aspect="equal")
+            ax_heat.set_xticks(range(3))
+            ax_heat.set_yticks(range(3))
+            ax_heat.set_xticklabels(lbls, fontsize=9, rotation=45)
+            ax_heat.set_yticklabels(lbls, fontsize=9)
+            ax_heat.set_title("Average cosine similarity", fontsize=10)
+            for i in range(3):
+                for j in range(3):
+                    val = avg_mat[i, j]
+                    fc = "white" if abs(val) > 0.75 else "black"
+                    ax_heat.text(j, i, f"{val:.2f}", ha="center", va="center",
+                                 fontsize=9, color=fc)
+            fig.colorbar(im, ax=ax_heat, fraction=0.046, pad=0.04,
+                         label="cosine similarity")
+
+            for pi, pj, pair_label, color in PAIR_INFO:
+                vals = [cosine_mats[k][pi, pj] for k in tel_keys]
+                ax_hist.hist(vals, bins=bins, histtype="step",
+                             color=color, label=pair_label, lw=1.5)
+            ax_hist.set_xlim(-1, 1)
+            ax_hist.set_xlabel("Cosine similarity", fontsize=11)
+            ax_hist.set_ylabel("Number of models", fontsize=11)
+            ax_hist.set_title("Distribution across models", fontsize=10)
+            ax_hist.legend(fontsize=8)
+            ax_hist.grid(True, alpha=0.3)
+
+            fig.tight_layout()
+            pdf.savefig(fig)
+            plt.close(fig)
+
+    print(f"Saved plots → {pdf_path}")
+
+print(f"Probe cache in {CACHE_DIR}")
+
+# ── 8. Average cosine-similarity matrices (HSC + JWST side by side) ─────────────
+avg_cos_pdf = (
+    f"{OUT_DIR}/avg_cosine_similarity_{n_valid}galaxies{UPSAMPLE_SUFFIX}.pdf"
+)
+lbls = [PROP_LABEL[p] for p in TARGET_PROPS]
+
+with PdfPages(avg_cos_pdf) as pdf:
+    fig, axes = plt.subplots(1, 2, figsize=(9, 5))
+    #fig.suptitle(
+    #    "Average probe weight cosine similarity (mean ± std across models)\n"
+    #    f"Axes: {' / '.join(lbls)}",
+    #    fontsize=12,
+    #)
+
+    last_im = None
+    for ax, telescope in zip(axes, TELESCOPES):
+        tel_keys = [k for k in all_results if k[0] == telescope]
+        if not tel_keys:
+            ax.set_visible(False)
+            continue
+
+        mats    = np.stack([cosine_mats[k] for k in tel_keys], axis=0)  # (N, 3, 3)
+        avg_mat = mats.mean(axis=0)
+        std_mat = mats.std(axis=0)
+
+        last_im = ax.imshow(avg_mat, vmin=-1, vmax=1, cmap="RdBu_r", aspect="equal")
+        ax.set_xticks(range(3))
+        ax.set_yticks(range(3))
+        ax.set_xticklabels(lbls, fontsize=9, rotation=45)
+        ax.set_yticklabels(lbls, fontsize=9)
+        ax.set_title(f"{telescope.upper()} (n={len(tel_keys)} models)", fontsize=11)
+
+        for i in range(3):
+            for j in range(3):
+                val = avg_mat[i, j]
+                std = std_mat[i, j]
+                fc  = "white" if abs(val) > 0.75 else "black"
+                ax.text(j, i, f"{val:.2f}\n±{std:.2f}",
+                        ha="center", va="center", fontsize=12, color=fc)
+
+    if last_im is not None:
+        fig.colorbar(last_im, ax=axes.tolist(), fraction=0.025, pad=0.04,
+                     label="cosine similarity", location='top')
+
+    fig.tight_layout()
+    pdf.savefig(fig)
+    plt.close(fig)
+
+print(f"Saved average cosine similarity PDF → {avg_cos_pdf}")
+
+# ── 9. Save all Procrustes distances ────────────────────────────────────────────
+proc_all = {
+    "cross_model_pairwise":    proc_disp,
+    "intra_modal_adjacent":    adj_disp,
+    "cross_modal_hsc_vs_jwst": cross_modal_disp,
+}
+proc_save_path = f"{OUT_DIR}/procrustes_distances_{n_valid}galaxies{UPSAMPLE_SUFFIX}.pkl"
+with open(proc_save_path, "wb") as f:
+    pickle.dump(proc_all, f)
+print(f"Saved Procrustes distances to {proc_save_path}")

--- a/experiments/cosmosweb/run_crossmodal.py
+++ b/experiments/cosmosweb/run_crossmodal.py
@@ -1,0 +1,498 @@
+"""
+CosmosWeb physics experiment — pu adapter/registry version.
+
+Uses the the pu adapter/registry system for both model loading and dataset streaming.
+
+Pipeline:
+  1. Catalog pass  — stream the raw dataset once (no model) to collect physical
+                     parameters.
+  2. Embedding     — for each model size, use get_dataset_adapter("cosmosweb")
+                     + DataLoader to embed images, caching results to .npy.
+  3. Analysis      — Wasserstein distance, MKNN overlap, linear probe R² scaling.
+  4. Plots         — PDF output identical to the original script.
+"""
+
+import os
+
+import matplotlib.pyplot as plt
+import numpy as np
+import torch
+from datasets import load_dataset
+from huggingface_hub import login
+from matplotlib.backends.backend_pdf import PdfPages
+from sklearn.linear_model import LinearRegression
+from sklearn.metrics import r2_score
+from sklearn.model_selection import train_test_split
+from sklearn.neighbors import NearestNeighbors
+from sklearn.preprocessing import StandardScaler
+from torch.utils.data import DataLoader
+from tqdm import tqdm
+
+from pu.metrics.neighbors import mknn_neighbor_input
+from pu.metrics.physics import wass_distance
+from pu.models import get_adapter
+from pu.pu_datasets import get_dataset_adapter
+from pu.pu_datasets.cosmosweb import CATALOG_COLUMNS
+
+
+# ── Config ─────────────────────────────────────────────────────────────────────
+model_map = {
+    "vit": (
+        ["base", "large", "huge"],
+        [
+            "google/vit-base-patch16-224-in21k",
+            "google/vit-large-patch16-224-in21k",
+            "google/vit-huge-patch14-224-in21k",
+        ],
+    ),
+    "clip": (
+        ["base", "large"],
+        [
+            "openai/clip-vit-base-patch16",
+            "openai/clip-vit-large-patch14",
+        ],
+    ),
+    "dinov3": (
+        ["vits16", "vits16plus", "vitb16", "vitl16", "vith16plus", "vit7b16"],
+        [
+            "facebook/dinov3-vits16-pretrain-lvd1689m",
+            "facebook/dinov3-vits16plus-pretrain-lvd1689m",
+            "facebook/dinov3-vitb16-pretrain-lvd1689m",
+            "facebook/dinov3-vitl16-pretrain-lvd1689m",
+            "facebook/dinov3-vith16plus-pretrain-lvd1689m",
+            "facebook/dinov3-vit7b16-pretrain-lvd1689m",
+        ],
+    ),
+    "convnext": (
+        ["nano", "tiny", "base", "large"],
+        [f"facebook/convnextv2-{s}-22k-224" for s in ["nano", "tiny", "base", "large"]],
+    ),
+    "ijepa": (
+        ["huge", "giant"],
+        ["facebook/ijepa_vith14_22k", "facebook/ijepa_vitg16_22k"],
+    ),
+    "vjepa": (
+        ["large", "huge", "giant"],
+        [
+            "facebook/vjepa2-vitl-fpc64-256",
+            "facebook/vjepa2-vith-fpc64-256",
+            "facebook/vjepa2-vitg-fpc64-256",
+        ],
+    ),
+    "astropt": (
+        ["015M", "095M", "850M"],
+        [f"Smith42/astroPT_v2.0" for _ in range(3)],
+    ),
+    "vit-mae": (
+        ["base", "large", "huge"],
+        [f"facebook/vit-mae-{s}" for s in ["base", "large", "huge"]],
+    ),
+    "paligemma": (
+        ["3b", "10b", "28b"],
+        [
+            "google/paligemma2-3b-mix-224",
+            "google/paligemma2-10b-mix-224",
+            "google/paligemma2-28b-mix-224",
+        ],
+    ),
+    "llava_15": (
+        ["7b", "13b"],
+        [
+            "llava-hf/llava-1.5-7b-hf",
+            "llava-hf/llava-1.5-13b-hf",
+        ],
+    ),
+}
+
+model_params_M = {
+    "vit":       {"base": 86,    "large": 307,   "huge": 632},
+    "clip":      {"base": 86,    "large": 307},
+    "dinov3":    {"vits16": 22,  "vits16plus": 26, "vitb16": 86,
+                  "vitl16": 307, "vith16plus": 650, "vit7b16": 7000},
+    "convnext":  {"nano": 16,    "tiny": 29,     "base": 89,     "large": 198},
+    "ijepa":     {"huge": 632,   "giant": 1011},
+    "vjepa":     {"large": 307,  "huge": 632,    "giant": 1011},
+    "astropt":   {"015M": 15,    "095M": 95,     "850M": 850},
+    "vit-mae":   {"base": 86,    "large": 307,   "huge": 632},
+    "paligemma": {"3b": 3000,    "10b": 10000,   "28b": 28000},
+    "llava_15":  {"7b": 7000,    "13b": 13000},
+}
+
+DATASET         = ""
+telescopes      = ["hsc", "jwst"]
+N_USE           = 45000
+BATCH_SIZE      = 128
+OUT_DIR         = ""
+n_neighbors     = 10
+N_PROBE_RUNS    = 10
+PROBE_TEST_SIZE = 5000
+
+DS_TAG          = DATASET.split("/")[-1]
+
+DEVICE = "cuda" if torch.cuda.is_available() else "cpu"
+print(f"Device: {DEVICE}")
+os.makedirs(OUT_DIR, exist_ok=True)
+os.makedirs(f"{OUT_DIR}/embeddings", exist_ok=True)
+
+
+# ── 1. Catalog pass (no model) ─────────────────────────────────────────────────
+# Stream the raw dataset once to collect physical parameters.  No image
+# preprocessing happens here — we only read the catalog columns.
+print(f"Loading catalog from {N_USE} galaxies in {DATASET}...")
+ds_raw = load_dataset(DATASET, split="train", streaming=True)
+
+params_raw = {k: [] for k in CATALOG_COLUMNS}
+for row in tqdm(ds_raw, total=N_USE, desc="Catalog pass"):
+    for param, col in CATALOG_COLUMNS.items():
+        params_raw[param].append(row[col])
+    if len(params_raw["redshift"]) >= N_USE:
+        break
+
+params = {k: np.array(v, dtype=np.float32) for k, v in params_raw.items()}
+params["g-r"] = params["mag_g"] - params["mag_r"]
+n_valid = len(params["redshift"])
+print(f"Loaded {n_valid} galaxies.")
+
+
+# ── 2. Preprocessor builder ────────────────────────────────────────────────────
+def _make_cosmosweb_preprocessor(adapter, telescope):
+    """Return a dataset.map-compatible callable for cosmosweb PIL images.
+
+    Output keys match embed_for_mode expectations per adapter type:
+      - HF models  → {telescope: pixel_values_tensor}
+      - SAM2       → {telescope: transformed_tensor}
+      - AstroPT    → {telescope}_images and {telescope}_positions tensors
+    """
+    image_col = f"{telescope}_images"
+
+    # ---- HF-style models (vit, clip, dino, dinov3, convnext, ijepa, vjepa, vit-mae, hiera) ----
+    if hasattr(adapter, "processor") and adapter.processor is not None:
+        proc = adapter.processor
+
+        def _hf_wrapper(example):
+            img = example[image_col]
+            if adapter.alias == "clip":
+                proc_out = proc(images=img, return_tensors="pt")
+            elif hasattr(adapter, "_PROMPTS"):
+                prompt = adapter._PROMPTS.get(adapter.alias, "<image> ")
+                proc_out = proc(text=prompt, images=img, return_tensors="pt")
+            else:
+                proc_out = proc(img, return_tensors="pt")
+            if "pixel_values" in proc_out:
+                return {telescope: proc_out["pixel_values"].squeeze(0)}
+            if "pixel_values_videos" in proc_out:
+                # vjepa outputs a video tensor; replicate single frame to 16
+                return {
+                    telescope: proc_out["pixel_values_videos"]
+                    .repeat(1, 16, 1, 1, 1)
+                    .squeeze(0)
+                }
+            raise KeyError("Processor output missing pixel_values")
+
+        return _hf_wrapper
+
+    # ---- SAM2 ----
+    if adapter.alias == "sam2":
+        sam2_transforms = adapter.predictor._transforms
+
+        def _sam2_wrapper(example):
+            img = example[image_col]
+            arr = np.asarray(img)
+            if arr.ndim == 2:
+                arr = np.stack([arr, arr, arr], axis=-1)
+            return {telescope: sam2_transforms(arr)}
+
+        return _sam2_wrapper
+
+    # ---- AstroPT ----
+    if adapter.alias == "astropt":
+        import torch as _torch
+        from astropt.local_datasets import GalaxyImageDataset
+        from torchvision import transforms
+
+        def _normalise(x):
+            std, mean = _torch.std_mean(x, dim=1, keepdim=True)
+            return (x - mean) / (std + 1e-8)
+
+        data_tf = transforms.Compose([transforms.Lambda(_normalise)])
+        galproc = GalaxyImageDataset(
+            None,
+            spiral=True,
+            transform={"images": data_tf},
+            modality_registry=adapter.model.modality_registry,
+        )
+
+        def _astropt_wrapper(example):
+            img = example[image_col]
+            arr = np.asarray(img, dtype=np.float32)
+            if arr.ndim == 2:
+                arr = np.stack([arr, arr, arr], axis=-1)
+            arr = arr.swapaxes(0, 2)  # (H,W,C) -> (C,H,W)
+            t = _torch.from_numpy(arr).to(_torch.float).unsqueeze(0)  # (1,C,H,W)
+            t = _torch.nn.functional.interpolate(t, size=(224, 224), mode="bilinear", align_corners=False)
+            arr = t.squeeze(0).numpy()  # back to (C,H,W)
+            im = galproc.process_galaxy(
+                _torch.from_numpy(arr).to(_torch.float)  # arr already float (C,H,W)
+            ).to(_torch.float)
+            return {
+                f"{telescope}_images": im,
+                f"{telescope}_positions": _torch.arange(0, len(im), dtype=_torch.long),
+            }
+
+        return _astropt_wrapper
+
+    raise ValueError(
+        f"Cannot build cosmosweb preprocessor for '{adapter.alias}': "
+        "adapter has no .processor and is not sam2 or astropt"
+    )
+
+
+# ── 3. Compute embeddings + neighbors ─────────────────────────────────────────
+# For each model size we use the dataset adapter to stream and preprocess images,
+# then call adapter.embed_for_mode — exactly as physics_experiment.py does.
+#
+# The filterfun passed to prepare() mirrors the valid_idx filter above so the
+# resulting embeddings are row-aligned with the params arrays.
+
+embeddings_all = {}
+neighbors_all  = {}
+
+for telescope in telescopes:
+    embeddings_all[telescope] = {}
+    neighbors_all[telescope] = {}
+    for model_alias, (sizes, model_names) in model_map.items():
+        adapter_cls = get_adapter(model_alias)
+        embeddings_all[telescope][model_alias] = {}
+        neighbors_all[telescope][model_alias]  = {}
+    
+        for size, model_name in zip(sizes, model_names):
+            print(f"\n{'='*60}")
+            print(f"Model: {model_alias} {size}  ({model_name})")
+            print(f"{'='*60}")
+    
+            cache_path = (
+                f"{OUT_DIR}/embeddings/"
+                f"{telescope}_embeddings_{DS_TAG}_{model_alias}_{size}_{n_valid}_upsampled.npy"
+            )
+            nn_cache_path = (
+                f"{OUT_DIR}/embeddings/"
+                f"{telescope}_nn{n_neighbors}_{DS_TAG}_{model_alias}_{size}_{n_valid}_upsampled.npy"
+            )
+
+            print(f"  Loading cached embeddings from {cache_path}")
+            embeddings = np.load(cache_path)
+
+            print(f"  Embeddings shape: {embeddings.shape}")
+            embeddings_all[telescope][model_alias][size] = embeddings
+
+            if os.path.exists(nn_cache_path):
+                print(f"  Loading cached NN matrix from {nn_cache_path}")
+                nn = np.load(nn_cache_path)
+            else:
+                nn = (
+                    NearestNeighbors(n_neighbors=n_neighbors, metric="minkowski")
+                    .fit(embeddings)
+                    .kneighbors(return_distance=False)
+                )
+                np.save(nn_cache_path, nn)
+                print(f"  Saved NN matrix to {nn_cache_path}")
+            neighbors_all[telescope][model_alias][size] = nn
+
+
+# ── 4. Cross-modal Wasserstein + MKNN (HSC vs JWST, per size) ─────────────────
+results_w_d  = {}
+results_mknn = {}
+
+for model_alias, (sizes, _) in model_map.items():
+    results_w_d[model_alias]  = {}
+    results_mknn[model_alias] = {}
+    for size in sizes:
+        w_ds = {}
+        for param_name, param_vals in params.items():
+            scaler = StandardScaler()
+            scaled = scaler.fit_transform(param_vals.reshape(-1, 1)).ravel()
+            w_ds[param_name] = wass_distance(
+                neighbors_all["hsc"][model_alias][size],
+                neighbors_all["jwst"][model_alias][size],
+                scaled,
+            )
+        results_w_d[model_alias][size] = w_ds
+        results_mknn[model_alias][size] = mknn_neighbor_input(
+            neighbors_all["hsc"][model_alias][size],
+            neighbors_all["jwst"][model_alias][size],
+        )
+
+
+# ── 5. Load linear-probe R² results (produced by cosmosweb_physics_experiment_pu.py) ──
+import json
+
+r2_hsc_path = f"{OUT_DIR}/hsc_linear_probe_r2_{n_valid}galaxies_upsampled.json"
+r2_jwst_path = f"{OUT_DIR}/jwst_linear_probe_r2_{n_valid}galaxies_upsampled.json"
+
+with open(r2_hsc_path) as f:
+    r2_hsc = json.load(f)
+print(f"Loaded HSC R² from {r2_hsc_path}")
+
+with open(r2_jwst_path) as f:
+    r2_jwst = json.load(f)
+print(f"Loaded JWST R² from {r2_jwst_path}")
+
+
+# ── 6. Plots ──────────────────────────────────────────────────────────────────
+param_names  = list(params.keys())
+model_colors = plt.rcParams["axes.prop_cycle"].by_key()["color"]
+color_map    = {alias: c for alias, c in zip(model_map.keys(), model_colors)}
+
+
+def _fmt_params(val, _):
+    if val >= 1000:
+        return f"{val/1000:.4g}B"
+    return f"{val:.4g}M"
+
+
+# ── 6a. Wasserstein distance as a function of model size ──────────────────────
+wass_pdf_path = f"{OUT_DIR}/cross_modal_wasserstein_vs_size_{n_neighbors}neighbors.pdf"
+with PdfPages(wass_pdf_path) as pdf:
+    for param in param_names:
+        fig, ax = plt.subplots(figsize=(9, 5))
+        for model_alias, (sizes, _) in model_map.items():
+            params_M = model_params_M.get(model_alias, {})
+            valid_sizes = [s for s in sizes if s in results_w_d[model_alias] and s in params_M]
+            if not valid_sizes:
+                continue
+            x = np.array([params_M[s] for s in valid_sizes], dtype=float)
+            y = [np.mean(results_w_d[model_alias][s][param]) for s in valid_sizes]
+            ax.plot(
+                x, y, marker="o", lw=1.8, ms=6,
+                color=color_map[model_alias], label=model_alias,
+            )
+            for xi, size, yi in zip(x, valid_sizes, y):
+                ax.annotate(
+                    size, (xi, yi),
+                    textcoords="offset points", xytext=(0, 6),
+                    ha="center", fontsize=6, color=color_map[model_alias], alpha=0.8,
+                )
+        ax.set_xscale("log")
+        ax.xaxis.set_major_formatter(plt.FuncFormatter(_fmt_params))
+        ax.set_xlabel("Number of parameters", fontsize=11)
+        ax.set_ylabel("Mean Wasserstein distance (HSC vs JWST)", fontsize=11)
+        ax.set_title(
+            f"Cross-modal Wasserstein distance — {param}\n"
+            f"{n_valid} galaxies, {n_neighbors} neighbors",
+            fontsize=12,
+        )
+        ax.legend(fontsize=8, loc="best", ncol=2)
+        ax.grid(True, alpha=0.3)
+        fig.tight_layout()
+        pdf.savefig(fig)
+        plt.close(fig)
+
+print(f"Saved cross-modal Wasserstein plots to {wass_pdf_path}")
+
+
+# ── 6b. MKNN overlap as a function of model size ──────────────────────────────
+mknn_pdf_path = f"{OUT_DIR}/cross_modal_mknn_vs_size_{n_neighbors}neighbors.pdf"
+with PdfPages(mknn_pdf_path) as pdf:
+    fig, ax = plt.subplots(figsize=(9, 5))
+    for model_alias, (sizes, _) in model_map.items():
+        params_M = model_params_M.get(model_alias, {})
+        valid_sizes = [s for s in sizes if s in results_mknn[model_alias] and s in params_M]
+        if not valid_sizes:
+            continue
+        x = np.array([params_M[s] for s in valid_sizes], dtype=float)
+        y = [results_mknn[model_alias][s] for s in valid_sizes]
+        ax.plot(
+            x, y, marker="o", lw=1.8, ms=6,
+            color=color_map[model_alias], label=model_alias,
+        )
+        for xi, size, yi in zip(x, valid_sizes, y):
+            ax.annotate(
+                size, (xi, yi),
+                textcoords="offset points", xytext=(0, 6),
+                ha="center", fontsize=6, color=color_map[model_alias], alpha=0.8,
+            )
+    ax.set_xscale("log")
+    ax.xaxis.set_major_formatter(plt.FuncFormatter(_fmt_params))
+    ax.set_xlabel("Number of parameters", fontsize=11)
+    ax.set_ylabel("MKNN overlap (HSC vs JWST)", fontsize=11)
+    ax.set_title(
+        f"Cross-modal MKNN overlap vs model size\n"
+        f"{n_valid} galaxies, {n_neighbors} neighbors",
+        fontsize=12,
+    )
+    ax.legend(fontsize=8, loc="best", ncol=2)
+    ax.grid(True, alpha=0.3)
+    fig.tight_layout()
+    pdf.savefig(fig)
+    plt.close(fig)
+
+print(f"Saved cross-modal MKNN vs size plots to {mknn_pdf_path}")
+
+
+# ── 6c. MKNN overlap vs linear-probe R² ──────────────────────────────────────
+# One scatter per physical parameter; each point = (model_alias, size).
+# Two versions: R² from HSC embeddings, and R² from JWST embeddings.
+
+def _plot_mknn_vs_r2(r2_dict, telescope_label, pdf_path):
+    with PdfPages(pdf_path) as pdf:
+        for param in param_names:
+            fig, ax = plt.subplots(figsize=(8, 5))
+            for model_alias, (sizes, _) in model_map.items():
+                xs, ys, labels = [], [], []
+                for size in sizes:
+                    r2_entry = r2_dict.get(model_alias, {}).get(size, {}).get(param)
+                    if r2_entry is None:
+                        continue
+                    r2_mean = r2_entry["r2_mean"]
+                    r2_std  = r2_entry["r2_std"]
+                    mknn    = results_mknn[model_alias][size]
+                    xs.append(r2_mean)
+                    ys.append(mknn)
+                    labels.append(size)
+                    ax.errorbar(
+                        r2_mean, mknn,
+                        xerr=r2_std,
+                        fmt="o", color=color_map[model_alias],
+                        ms=7, capsize=3, capthick=1, elinewidth=1,
+                    )
+                    ax.annotate(
+                        f"{model_alias}\n{size}", (r2_mean, mknn),
+                        textcoords="offset points", xytext=(5, 3),
+                        fontsize=5, color=color_map[model_alias], alpha=0.85,
+                    )
+                if xs:
+                    # Connect sizes within the same model family with a line
+                    order = np.argsort(xs)
+                    ax.plot(
+                        [xs[i] for i in order], [ys[i] for i in order],
+                        lw=1, ls="--", color=color_map[model_alias],
+                        alpha=0.5, label=model_alias,
+                    )
+            #ax.set_xlim(0,1)
+            ax.set_xlabel(f"Linear probe R² ({telescope_label})", fontsize=11)
+            ax.set_ylabel("MKNN overlap (HSC vs JWST)", fontsize=11)
+            ax.set_title(
+                f"Cross-modal MKNN vs R² ({telescope_label}) — {param}\n"
+                f"{n_valid} galaxies, {n_neighbors} neighbors",
+                fontsize=12,
+            )
+            ax.legend(fontsize=8, loc="best", ncol=2)
+            ax.grid(True, alpha=0.3)
+            fig.tight_layout()
+            pdf.savefig(fig)
+            plt.close(fig)
+
+    print(f"Saved MKNN vs R² ({telescope_label}) plots to {pdf_path}")
+
+
+_plot_mknn_vs_r2(
+    r2_hsc,
+    "HSC",
+    f"{OUT_DIR}/cross_modal_mknn_vs_r2_hsc_{n_neighbors}neighbors.pdf",
+)
+
+_plot_mknn_vs_r2(
+    r2_jwst,
+    "JWST",
+    f"{OUT_DIR}/cross_modal_mknn_vs_r2_jwst_{n_neighbors}neighbors.pdf",
+)

--- a/experiments/cosmosweb/run_intramodal.py
+++ b/experiments/cosmosweb/run_intramodal.py
@@ -1,0 +1,579 @@
+"""
+CosmosWeb physics experiment — pu adapter/registry version.
+
+Uses the pu adapter/registry system for both model loading and dataset streaming.
+
+Pipeline:
+  1. Catalog pass  — stream the raw dataset once (no model) to collect physical
+                     parameters.
+  2. Embedding     — for each model size, use get_dataset_adapter("cosmosweb")
+                     + DataLoader to embed images, caching results to .npy.
+  3. Analysis      — Wasserstein distance, MKNN overlap, linear probe R² scaling.
+  4. Plots         — PDF output identical to the original script.
+"""
+
+import os
+
+import matplotlib.pyplot as plt
+import numpy as np
+import torch
+from datasets import load_dataset
+from huggingface_hub import login
+from matplotlib.backends.backend_pdf import PdfPages
+from PIL import Image
+from sklearn.linear_model import LinearRegression
+from sklearn.metrics import r2_score
+from sklearn.model_selection import train_test_split
+from sklearn.neighbors import NearestNeighbors
+from sklearn.preprocessing import StandardScaler
+from torch.utils.data import DataLoader
+from tqdm import tqdm
+
+from pu.metrics.neighbors import mknn_neighbor_input
+from pu.metrics.physics import wass_distance
+from pu.models import get_adapter
+from pu.pu_datasets import get_dataset_adapter
+from pu.pu_datasets.cosmosweb import CATALOG_COLUMNS
+
+
+# ── Config ─────────────────────────────────────────────────────────────────────
+model_map = {
+    "vit": (
+        ["base", "large", "huge"],
+        [
+            "google/vit-base-patch16-224-in21k",
+            "google/vit-large-patch16-224-in21k",
+            "google/vit-huge-patch14-224-in21k",
+        ],
+    ),
+    "clip": (
+        ["base", "large"],
+        [
+            "openai/clip-vit-base-patch16",
+            "openai/clip-vit-large-patch14",
+        ],
+    ),
+    "dinov3": (
+        ["vits16", "vits16plus", "vitb16", "vitl16", "vith16plus", "vit7b16"],
+        [
+            "facebook/dinov3-vits16-pretrain-lvd1689m",
+            "facebook/dinov3-vits16plus-pretrain-lvd1689m",
+            "facebook/dinov3-vitb16-pretrain-lvd1689m",
+            "facebook/dinov3-vitl16-pretrain-lvd1689m",
+            "facebook/dinov3-vith16plus-pretrain-lvd1689m",
+            "facebook/dinov3-vit7b16-pretrain-lvd1689m",
+        ],
+    ),
+    "convnext": (
+        ["nano", "tiny", "base", "large"],
+        [f"facebook/convnextv2-{s}-22k-224" for s in ["nano", "tiny", "base", "large"]],
+    ),
+    "ijepa": (
+        ["huge", "giant"],
+        ["facebook/ijepa_vith14_22k", "facebook/ijepa_vitg16_22k"],
+    ),
+    "vjepa": (
+        ["large", "huge", "giant"],
+        [
+            "facebook/vjepa2-vitl-fpc64-256",
+            "facebook/vjepa2-vith-fpc64-256",
+            "facebook/vjepa2-vitg-fpc64-256",
+        ],
+    ),
+    "astropt": (
+        ["015M", "095M", "850M"],
+        [f"Smith42/astroPT_v2.0" for _ in range(3)],
+    ),
+    "vit-mae": (
+        ["base", "large", "huge"],
+        [f"facebook/vit-mae-{s}" for s in ["base", "large", "huge"]],
+    ),
+    "paligemma": (
+        ["3b", "10b", "28b"],
+        [
+            "google/paligemma2-3b-mix-224",
+            "google/paligemma2-10b-mix-224",
+            "google/paligemma2-28b-mix-224",
+        ],
+    ),
+    "llava_15": (
+        ["7b", "13b"],
+        [
+            "llava-hf/llava-1.5-7b-hf",
+            "llava-hf/llava-1.5-13b-hf",
+        ],
+    ),
+}
+
+# Parameter counts in millions for each (model_alias, size).
+# Sources: model cards / published papers.
+model_params_M = {
+    "vit":       {"base": 86,    "large": 307,   "huge": 632},
+    "clip":      {"base": 86,    "large": 307},
+    "dinov3":    {"vits16": 22,  "vits16plus": 26, "vitb16": 86,
+                  "vitl16": 307, "vith16plus": 650, "vit7b16": 7000},
+    "convnext":  {"nano": 16,    "tiny": 29,     "base": 89,     "large": 198},
+    "ijepa":     {"huge": 632,   "giant": 1011},
+    "vjepa":     {"large": 307,  "huge": 632,    "giant": 1011},
+    "astropt":   {"015M": 15,    "095M": 95,     "850M": 850},
+    "vit-mae":   {"base": 86,    "large": 307,   "huge": 632},
+    "paligemma": {"3b": 3000,    "10b": 10000,   "28b": 28000},
+    "llava_15":  {"7b": 7000,    "13b": 13000},
+}
+
+DATASET          = ""
+telescope        = "jwst"
+N_USE            = 45000
+BATCH_SIZE       = 16
+OUT_DIR          = ""
+n_neighbors      = 10
+N_PROBE_RUNS     = 10
+PROBE_TEST_SIZE  = 5000
+upsample_images  = True   # bilinear-upsample all images to 224×224 before any model preprocessing
+
+UPSAMPLE_SUFFIX  = "_upsampled" if upsample_images else ""
+DS_TAG           = DATASET.split("/")[-1]
+
+DEVICE = "cuda" if torch.cuda.is_available() else "cpu"
+print(f"Device: {DEVICE}")
+os.makedirs(OUT_DIR, exist_ok=True)
+os.makedirs(f"{OUT_DIR}/embeddings", exist_ok=True)
+
+
+# ── 1. Catalog pass (no model) ─────────────────────────────────────────────────
+# Stream the raw dataset once to collect physical parameters.  No image
+# preprocessing happens here — we only read the catalog columns.
+print(f"Loading catalog from {N_USE} galaxies in {DATASET}...")
+ds_raw = load_dataset(DATASET, split="train", streaming=True)
+
+params_raw = {k: [] for k in CATALOG_COLUMNS}
+for row in tqdm(ds_raw, total=N_USE, desc="Catalog pass"):
+    for param, col in CATALOG_COLUMNS.items():
+        params_raw[param].append(row[col])
+    if len(params_raw["redshift"]) >= N_USE:
+        break
+
+params = {k: np.array(v, dtype=np.float32) for k, v in params_raw.items()}
+params["g-r"] = params["mag_g"] - params["mag_r"]
+n_valid = len(params["redshift"])
+print(f"Loaded {n_valid} galaxies.")
+
+
+# ── 2. Preprocessor builder ────────────────────────────────────────────────────
+def _make_cosmosweb_preprocessor(adapter, telescope, upsample_images=True):
+    """Return a dataset.map-compatible callable for cosmosweb PIL images.
+
+    Output keys match embed_for_mode expectations per adapter type:
+      - HF models  → {telescope: pixel_values_tensor}
+      - SAM2       → {telescope: transformed_tensor}
+      - AstroPT    → {telescope}_images and {telescope}_positions tensors
+
+    If upsample_images is True, every PIL image is bilinear-resized to
+    224×224 before being passed to the model-specific preprocessor.
+    """
+    image_col = f"{telescope}_images"
+    _TARGET = (224, 224)
+
+    def _maybe_upsample(img):
+        if upsample_images:
+            img = img.resize(_TARGET, Image.Resampling.BILINEAR)
+        return img
+
+    # ---- HF-style models (vit, clip, dino, dinov3, convnext, ijepa, vjepa, vit-mae, hiera) ----
+    if hasattr(adapter, "processor") and adapter.processor is not None:
+        proc = adapter.processor
+
+        def _hf_wrapper(example):
+            img = _maybe_upsample(example[image_col])
+            if adapter.alias == "clip":
+                proc_out = proc(images=img, return_tensors="pt")
+            elif hasattr(adapter, "_PROMPTS"):
+                prompt = adapter._PROMPTS.get(adapter.alias, "<image> ")
+                proc_out = proc(text=prompt, images=img, return_tensors="pt")
+            else:
+                proc_out = proc(img, return_tensors="pt")
+            if "pixel_values" in proc_out:
+                return {telescope: proc_out["pixel_values"].squeeze(0)}
+            if "pixel_values_videos" in proc_out:
+                # vjepa outputs a video tensor; replicate single frame to 16
+                return {
+                    telescope: proc_out["pixel_values_videos"]
+                    .repeat(1, 16, 1, 1, 1)
+                    .squeeze(0)
+                }
+            raise KeyError("Processor output missing pixel_values")
+
+        return _hf_wrapper
+
+    # ---- SAM2 ----
+    if adapter.alias == "sam2":
+        sam2_transforms = adapter.predictor._transforms
+
+        def _sam2_wrapper(example):
+            img = _maybe_upsample(example[image_col])
+            arr = np.asarray(img)
+            if arr.ndim == 2:
+                arr = np.stack([arr, arr, arr], axis=-1)
+            return {telescope: sam2_transforms(arr)}
+
+        return _sam2_wrapper
+
+    # ---- AstroPT ----
+    if adapter.alias == "astropt":
+        import torch as _torch
+        from astropt.local_datasets import GalaxyImageDataset
+        from torchvision import transforms
+
+        def _normalise(x):
+            std, mean = _torch.std_mean(x, dim=1, keepdim=True)
+            return (x - mean) / (std + 1e-8)
+
+        data_tf = transforms.Compose([transforms.Lambda(_normalise)])
+        galproc = GalaxyImageDataset(
+            None,
+            spiral=True,
+            transform={"images": data_tf},
+            modality_registry=adapter.model.modality_registry,
+        )
+
+        def _astropt_wrapper(example):
+            img = _maybe_upsample(example[image_col])
+            arr = np.asarray(img, dtype=np.float32)
+            if arr.ndim == 2:
+                arr = np.stack([arr, arr, arr], axis=-1)
+            arr = arr.swapaxes(0, 2)  # (H,W,C) -> (C,H,W)
+            t = _torch.from_numpy(arr).to(_torch.float).unsqueeze(0)  # (1,C,H,W)
+            # Only torch-interpolate when we haven't already upsampled via PIL
+            if not upsample_images:
+                t = _torch.nn.functional.interpolate(t, size=(224, 224), mode="bilinear", align_corners=False)
+            arr = t.squeeze(0).numpy()  # back to (C,H,W)
+            im = galproc.process_galaxy(
+                _torch.from_numpy(arr).to(_torch.float)  # arr already float (C,H,W)
+            ).to(_torch.float)
+            return {
+                f"{telescope}_images": im,
+                f"{telescope}_positions": _torch.arange(0, len(im), dtype=_torch.long),
+            }
+
+        return _astropt_wrapper
+
+    raise ValueError(
+        f"Cannot build cosmosweb preprocessor for '{adapter.alias}': "
+        "adapter has no .processor and is not sam2 or astropt"
+    )
+
+
+# ── 3. Compute embeddings + neighbors ─────────────────────────────────────────
+# For each model size we use the dataset adapter to stream and preprocess images,
+# then call adapter.embed_for_mode — exactly as physics_experiment.py does.
+#
+# The filterfun passed to prepare() mirrors the valid_idx filter above so the
+# resulting embeddings are row-aligned with the params arrays.
+
+embeddings_all = {}
+neighbors_all  = {}
+
+for model_alias, (sizes, model_names) in model_map.items():
+    adapter_cls = get_adapter(model_alias)
+    embeddings_all[model_alias] = {}
+    neighbors_all[model_alias]  = {}
+
+    for size, model_name in zip(sizes, model_names):
+        print(f"\n{'='*60}")
+        print(f"Model: {model_alias} {size}  ({model_name})")
+        print(f"{'='*60}")
+
+        cache_path = (
+            f"{OUT_DIR}/embeddings/"
+            f"{telescope}_embeddings_{DS_TAG}_{model_alias}_{size}_{n_valid}{UPSAMPLE_SUFFIX}.npy"
+        )
+        nn_cache_path = (
+            f"{OUT_DIR}/embeddings/"
+            f"{telescope}_nn{n_neighbors}_{DS_TAG}_{model_alias}_{size}_{n_valid}{UPSAMPLE_SUFFIX}.npy"
+        )
+
+        if os.path.exists(cache_path):
+            print(f"  Loading cached embeddings from {cache_path}")
+            embeddings = np.load(cache_path)
+        else:
+            # Load model via registry
+            adapter = adapter_cls(model_name, size, alias=model_alias)
+            adapter.load()
+
+            # Build preprocessor and stream dataset via the dataset adapter
+            proc_fn = _make_cosmosweb_preprocessor(adapter, telescope, upsample_images=upsample_images)
+
+            dataset_adapter = get_dataset_adapter("cosmosweb")(DATASET, telescope)
+            dataset_adapter.load()
+            ds = dataset_adapter.prepare(
+                processor=proc_fn,
+                modes=[telescope],
+                filterfun=lambda row: True,
+                telescope=telescope,
+                n_galaxies=N_USE,
+                # AstroPT's preprocessor overwrites {telescope}_images in-place,
+                # so we must NOT remove it after mapping.
+                remove_image_col=(model_alias != "astropt")
+            )
+            if model_alias == "astropt":
+                ds = ds.select_columns([f"{telescope}_images", f"{telescope}_positions"])
+            else:
+                ds = ds.select_columns([telescope])
+
+            dl = DataLoader(ds, batch_size=BATCH_SIZE, num_workers=0)
+
+            all_embs = []
+            for batch in tqdm(dl, desc="  Embedding"):
+                emb = adapter.embed_for_mode(batch, telescope).float().cpu()
+                all_embs.append(emb.numpy())
+                if sum(len(e) for e in all_embs) >= n_valid:
+                    break
+
+            embeddings = np.concatenate(all_embs, axis=0)[:n_valid]
+            np.save(cache_path, embeddings)
+            print(f"  Saved embeddings to {cache_path}")
+
+            del adapter
+            torch.cuda.empty_cache()
+
+        print(f"  Embeddings shape: {embeddings.shape}")
+        embeddings_all[model_alias][size] = embeddings
+
+        if os.path.exists(nn_cache_path):
+            print(f"  Loading cached NN matrix from {nn_cache_path}")
+            nn = np.load(nn_cache_path)
+        else:
+            nn = (
+                NearestNeighbors(n_neighbors=n_neighbors, metric="minkowski")
+                .fit(embeddings)
+                .kneighbors(return_distance=False)
+            )
+            np.save(nn_cache_path, nn)
+            print(f"  Saved NN matrix to {nn_cache_path}")
+        neighbors_all[model_alias][size] = nn
+
+
+# ── 4. Linear probes ──────────────────────────────────────────────────────────
+import json
+
+r2_path = f"{OUT_DIR}/{telescope}_linear_probe_r2_{n_valid}galaxies{UPSAMPLE_SUFFIX}.json"
+
+def run_probe(embeddings, y, test_size, random_state):
+    valid = np.isfinite(y)
+    X_v, y_v = embeddings[valid], y[valid]
+    lo, hi = np.quantile(y_v, [0.01, 0.99])
+    y_clipped = np.clip(y_v, lo, hi)
+    X_tr, X_te, y_tr, y_te = train_test_split(
+        X_v, y_clipped, test_size=test_size, random_state=random_state
+    )
+    scaler = StandardScaler()
+    X_tr = scaler.fit_transform(X_tr)
+    X_te = scaler.transform(X_te)
+    probe = LinearRegression().fit(X_tr, y_tr)
+    y_pred = probe.predict(X_te)
+    return dict(
+        y_test=y_te, y_pred=y_pred,
+        bias=float(np.mean(y_pred - y_te)),
+        r2=r2_score(y_te, y_pred),
+        lo=lo, hi=hi,
+        n_train=len(X_tr), n_test=len(X_te),
+    )
+
+
+def run_probe_averaged(embeddings, y, test_size, n_runs):
+    r2_list, last = [], None
+    for seed in range(n_runs):
+        pr = run_probe(embeddings, y, test_size=test_size, random_state=seed)
+        r2_list.append(pr["r2"])
+        last = pr
+    last["r2_all"]  = r2_list
+    last["r2_mean"] = float(np.mean(r2_list))
+    last["r2_std"]  = float(np.std(r2_list))
+    last["r2"]      = last["r2_mean"]
+    return last
+
+
+if os.path.exists(r2_path):
+    print(f"Loading cached R² results from {r2_path}")
+    with open(r2_path) as f:
+        r2_summary = json.load(f)
+    # Reconstruct results_probe in the shape expected by the plotting code
+    results_probe = {}
+    for model_alias, (sizes, _) in model_map.items():
+        results_probe[model_alias] = {}
+        for size in sizes:
+            results_probe[model_alias][size] = {
+                param_name: {
+                    "r2_mean": r2_summary[model_alias][size][param_name]["r2_mean"],
+                    "r2_std":  r2_summary[model_alias][size][param_name]["r2_std"],
+                }
+                for param_name in params
+            }
+else:
+    results_probe = {}
+    for model_alias, (sizes, _) in model_map.items():
+        results_probe[model_alias] = {}
+        for size in sizes:
+            print(f"\n  Linear probes: {model_alias} {size}  ({N_PROBE_RUNS} runs each)...")
+            embeddings = embeddings_all[model_alias][size]
+            param_results = {}
+            for param_name, param_vals in params.items():
+                pr = run_probe_averaged(embeddings, param_vals,
+                                        test_size=PROBE_TEST_SIZE, n_runs=N_PROBE_RUNS)
+                param_results[param_name] = pr
+                print(f"    {param_name:12s}  R²={pr['r2_mean']:.4f} ± {pr['r2_std']:.4f}")
+            results_probe[model_alias][size] = param_results
+
+    # ── Save linear probe R² results ──────────────────────────────────────────
+    r2_summary = {}
+    for model_alias, (sizes, _) in model_map.items():
+        r2_summary[model_alias] = {}
+        for size in sizes:
+            r2_summary[model_alias][size] = {
+                param_name: {
+                    "r2_mean": results_probe[model_alias][size][param_name]["r2_mean"],
+                    "r2_std":  results_probe[model_alias][size][param_name]["r2_std"],
+                }
+                for param_name in params
+            }
+
+    with open(r2_path, "w") as f:
+        json.dump(r2_summary, f, indent=2)
+    print(f"Saved R² results to {r2_path}")
+
+
+# ── 5. Wasserstein + MKNN ─────────────────────────────────────────────────────
+results_w_d  = {}
+results_mknn = {}
+
+for model_alias, (sizes, _) in model_map.items():
+    results_w_d[model_alias]  = {}
+    results_mknn[model_alias] = {}
+    for m in range(len(sizes) - 1):
+        key = f"{sizes[m]} vs {sizes[m+1]}"
+        w_ds = {}
+        for param_name, param_vals in params.items():
+            scaler = StandardScaler()
+            scaled = scaler.fit_transform(param_vals.reshape(-1, 1)).ravel()
+            w_ds[param_name] = wass_distance(
+                neighbors_all[model_alias][sizes[m]],
+                neighbors_all[model_alias][sizes[m+1]],
+                scaled,
+            )
+        results_w_d[model_alias][key] = w_ds
+        results_mknn[model_alias][key] = mknn_neighbor_input(
+            neighbors_all[model_alias][sizes[m]],
+            neighbors_all[model_alias][sizes[m+1]],
+        )
+
+
+# ── 6. Plots ──────────────────────────────────────────────────────────────────
+param_names = list(params.keys())
+
+# Wasserstein scaling
+pdf_path = f"{OUT_DIR}/{telescope}_wasserstein_scaling_{n_neighbors}neighbors{UPSAMPLE_SUFFIX}.pdf"
+with PdfPages(pdf_path) as pdf:
+    for param in param_names:
+        fig, ax = plt.subplots(figsize=(7, 4))
+        for model_alias, (sizes, _) in model_map.items():
+            comparisons = [f"{sizes[m]} vs {sizes[m+1]}" for m in range(len(sizes) - 1)]
+            y = [np.mean(results_w_d[model_alias][c][param]) for c in comparisons]
+            ax.plot(range(len(comparisons)), y, marker="o", label=model_alias)
+            ax.set_xticks(range(len(comparisons)))
+            ax.set_xticklabels(comparisons, rotation=15, ha="right")
+        ax.set_ylabel("Mean Wasserstein distance")
+        ax.set_xlabel("Model size comparison")
+        ax.set_title(f"Wasserstein scaling — {param}")
+        ax.legend()
+        fig.tight_layout()
+        pdf.savefig(fig)
+        plt.close(fig)
+
+        for model_alias, (sizes, _) in model_map.items():
+            fig, ax = plt.subplots(figsize=(7, 4))
+            comparisons = [f"{sizes[m]} vs {sizes[m+1]}" for m in range(len(sizes) - 1)]
+            for c in comparisons:
+                ax.hist(results_w_d[model_alias][c][param], histtype="step", bins=100, label=c)
+                ax.axvline(np.mean(results_w_d[model_alias][c][param]), c="k", ls="--", label="mean")
+                ax.axvline(np.median(results_w_d[model_alias][c][param]), c="m", ls="--", label="median")
+            ax.legend()
+            pdf.savefig(fig)
+            plt.close(fig)
+
+print(f"Saved Wasserstein plots to {pdf_path}")
+
+# MKNN scaling
+mknn_pdf_path = f"{OUT_DIR}/{telescope}_mknn_scaling_{n_neighbors}neighbors{UPSAMPLE_SUFFIX}.pdf"
+with PdfPages(mknn_pdf_path) as pdf:
+    fig, ax = plt.subplots(figsize=(7, 4))
+    for model_alias, (sizes, _) in model_map.items():
+        comparisons = [f"{sizes[m]} vs {sizes[m+1]}" for m in range(len(sizes) - 1)]
+        y = [results_mknn[model_alias][c] for c in comparisons]
+        ax.plot(range(len(comparisons)), y, marker="o", label=model_alias)
+        ax.set_xticks(range(len(comparisons)))
+        ax.set_xticklabels(comparisons, rotation=15, ha="right")
+    ax.set_ylabel("MKNN overlap")
+    ax.set_xlabel("Model size comparison")
+    ax.set_title("MKNN scaling — adjacent model sizes")
+    ax.legend()
+    fig.tight_layout()
+    pdf.savefig(fig)
+    plt.close(fig)
+
+print(f"Saved MKNN plots to {mknn_pdf_path}")
+
+# Linear probe R² scaling — one plot per parameter, all models overlaid
+probe_pdf_path = f"{OUT_DIR}/{telescope}_linear_probe_scaling_{n_neighbors}neighbors{UPSAMPLE_SUFFIX}.pdf"
+model_colors = plt.rcParams["axes.prop_cycle"].by_key()["color"]
+
+with PdfPages(probe_pdf_path) as pdf:
+    for param_name in params:
+        fig, ax = plt.subplots(figsize=(9, 5))
+        for color, (model_alias, (sizes, _)) in zip(model_colors, model_map.items()):
+            # if model_alias == "dinov3":
+            #     sizes = sizes[:-1]
+
+            params_M = model_params_M.get(model_alias, {})
+            sizes = [s for s in sizes if s in params_M]
+            if not sizes:
+                continue
+
+            x = np.array([params_M[s] for s in sizes], dtype=float)
+            r2_mean = np.array([results_probe[model_alias][s][param_name]["r2_mean"] for s in sizes])
+            r2_std  = np.array([results_probe[model_alias][s][param_name]["r2_std"]  for s in sizes])
+
+            ax.errorbar(
+                x, r2_mean, yerr=r2_std,
+                fmt="o-", color=color,
+                lw=1.8, ms=6, capsize=4, capthick=1.2, elinewidth=1.2,
+                label=model_alias,
+            )
+            # Annotate each point with its size label
+            for xi, size, r2m in zip(x, sizes, r2_mean):
+                ax.annotate(
+                    size, (xi, r2m),
+                    textcoords="offset points", xytext=(0, 6),
+                    ha="center", fontsize=6, color=color, alpha=0.8,
+                )
+
+        ax.set_xscale("log")
+        ax.set_xlabel("Number of parameters", fontsize=11)
+
+        def _fmt_params(val, _):
+            if val >= 1000:
+                return f"{val/1000:.4g}B"
+            return f"{val:.4g}M"
+        ax.xaxis.set_major_formatter(plt.FuncFormatter(_fmt_params))
+        ax.set_ylabel("R²", fontsize=11)
+        ax.set_title(
+            f"Linear probe R² — {param_name}\n"
+            f"{n_valid} {telescope.upper()} galaxies  (mean ± std, {N_PROBE_RUNS} runs)",
+            fontsize=12,
+        )
+        ax.legend(fontsize=8, loc="best", ncol=2)
+        ax.grid(True, alpha=0.3)
+        plt.tight_layout()
+        pdf.savefig(fig)
+        plt.close(fig)
+
+print(f"Saved linear probe plots to {probe_pdf_path}")

--- a/experiments/cosmosweb/test_linear_probe.py
+++ b/experiments/cosmosweb/test_linear_probe.py
@@ -1,0 +1,376 @@
+"""
+ConvNeXt V2 (Nano & Tiny) embeddings of HSC galaxy images from the CosmosWeb dataset.
+
+  - Generates / loads cached embeddings for each model
+  - UMAP for both models in one figure (side by side), colored by photometric redshift
+  - Linear probe (OLS) on train / test split, with standardized embeddings
+  - 10 random galaxy sample images (R, G, B channels with colorbars)
+  - R² scaling plot for redshift, g-r color, stellar mass, and sSFR
+
+Usage:
+    python tests/test_linear_probe_cosmosweb_convnext.py
+
+Key variables:
+    N_GALAXIES  - number of galaxies to use (default: 12000)
+    OUT_DIR     - directory for all outputs (embeddings, plots)
+    MODELS      - dict of {label: HuggingFace model ID}
+    BATCH_SIZE  - inference batch size
+"""
+
+import os
+import numpy as np
+import matplotlib.pyplot as plt
+from matplotlib.backends.backend_pdf import PdfPages
+import torch
+from datasets import load_dataset
+from transformers import AutoModel, AutoImageProcessor
+from tqdm import tqdm
+import umap
+from sklearn.linear_model import LinearRegression
+from sklearn.preprocessing import StandardScaler
+from sklearn.model_selection import train_test_split
+from sklearn.metrics import r2_score
+
+# ── Configuration ─────────────────────────────────────────────────────────────
+N_GALAXIES = 45000
+DATASET    = "Ashodkh/cosmosweb-hsc-jwst-high-snr-pil2"
+BATCH_SIZE = 128
+OUT_DIR    = "/pscratch/sd/a/ashodkh/platonic_universe"
+MODELS     = {
+    "nano":  "facebook/convnextv2-nano-22k-224",
+    "tiny":  "facebook/convnextv2-tiny-22k-224",
+    "base":  "facebook/convnextv2-base-22k-224",
+    "large": "facebook/convnextv2-large-22k-224",
+}
+N_SAMPLE_IMAGES = 10
+N_PROBE_RUNS    = 10      # number of random train/test splits for averaging
+# ──────────────────────────────────────────────────────────────────────────────
+
+DEVICE = "cuda" if torch.cuda.is_available() else "cpu"
+print(f"Device: {DEVICE}")
+os.makedirs(OUT_DIR, exist_ok=True)
+
+
+# ── 1. Load dataset ────────────────────────────────────────────────────────────
+print(f"Loading {N_GALAXIES} galaxies from {DATASET}...")
+ds = load_dataset(DATASET, split="train", streaming=True)
+
+images   = []
+redshift = []
+mag_g    = []
+mag_r    = []
+lp_mass  = []
+lp_ssfr  = []
+i = 0
+for row in tqdm(ds, total=N_GALAXIES, desc="Fetching"):
+    #print(i)
+    images.append(row["hsc_images"])
+    redshift.append(row["lephare_photozs"])
+    mag_g.append(row["mag_model_hsc-g"])
+    mag_r.append(row["mag_model_hsc-r"])
+    lp_mass.append(row["lp_mass"])
+    lp_ssfr.append(row["lp_ssfr"])
+    i += 1
+    if len(images) >= N_GALAXIES:
+        break
+
+redshift = np.array(redshift, dtype=np.float32)
+mag_g    = np.array(mag_g,    dtype=np.float32)
+mag_r    = np.array(mag_r,    dtype=np.float32)
+lp_mass  = np.array(lp_mass,  dtype=np.float32)
+lp_ssfr  = np.array(lp_ssfr,  dtype=np.float32)
+
+# Keep only positive redshifts, clipped to [0, 4]
+valid_idx = np.where(redshift > 0)[0]
+images    = [images[i] for i in valid_idx]
+redshift  = np.clip(redshift[valid_idx], 0, 4)
+mag_g     = mag_g[valid_idx]
+mag_r     = mag_r[valid_idx]
+lp_mass   = lp_mass[valid_idx]
+lp_ssfr   = lp_ssfr[valid_idx]
+gr_color  = mag_g - mag_r
+
+print(f"After filtering: {len(images)} galaxies.  z range: [{redshift.min():.3f}, {redshift.max():.3f}]")
+
+# Physical parameters for probing
+PHYS_PARAMS = {
+    "redshift":  redshift,
+    "g-r color": gr_color,
+    "mag g":     mag_g,
+    "mag r":     mag_r,
+    "log mass":  lp_mass,
+    "log sSFR":  lp_ssfr,
+}
+
+
+# ── 2. Visualise 10 random sample images ──────────────────────────────────────
+print("Saving sample galaxy images...")
+rng      = np.random.default_rng(0)
+idx_show = rng.choice(len(images), size=N_SAMPLE_IMAGES, replace=False)
+
+fig, axes = plt.subplots(
+    N_SAMPLE_IMAGES, 3,
+    figsize=(9, N_SAMPLE_IMAGES * 2.8),
+    gridspec_kw={"hspace": 0.05, "wspace": 0.35},
+)
+ch_labels = ["R", "G", "B"]
+ch_cmaps  = ["Reds_r", "Greens_r", "Blues_r"]
+
+for row_i, gal_idx in enumerate(idx_show):
+    arr = np.array(images[gal_idx])          # (H, W, 3) uint8
+    for ch in range(3):
+        ax = axes[row_i, ch]
+        im = ax.imshow(arr[:, :, ch], cmap=ch_cmaps[ch], origin="upper")
+        fig.colorbar(im, ax=ax, fraction=0.046, pad=0.04)
+        if row_i == 0:
+            ax.set_title(ch_labels[ch], fontsize=10)
+        ax.axis("off")
+    axes[row_i, 0].set_ylabel(f"z={redshift[gal_idx]:.2f}", fontsize=8, rotation=0,
+                               labelpad=30, va="center")
+
+fig.suptitle("10 random HSC galaxies — R, G, B channels (pixel values 0–255)",
+             fontsize=11, y=1.002)
+sample_path = f"{OUT_DIR}/galaxy_samples_cosmosweb_{N_GALAXIES}.png"
+fig.savefig(sample_path, dpi=150, bbox_inches="tight")
+plt.close(fig)
+print(f"Saved sample images to {sample_path}")
+
+
+# ── 3. Embedding function ──────────────────────────────────────────────────────
+def compute_embeddings(images, model_name, batch_size, device):
+    processor = AutoImageProcessor.from_pretrained(model_name)
+    model     = AutoModel.from_pretrained(model_name).to(device).eval()
+    all_embs  = []
+    for i in tqdm(range(0, len(images), batch_size), desc="  Embedding"):
+        batch  = images[i : i + batch_size]
+        inputs = processor(images=batch, return_tensors="pt")["pixel_values"].to(device)
+        with torch.no_grad():
+            feats = model(inputs).last_hidden_state   # (B, C, H, W)
+            emb   = feats.mean(dim=(2, 3)).float()    # spatial mean → (B, C)
+        all_embs.append(emb.cpu().numpy())
+    del model
+    torch.cuda.empty_cache()
+    return np.concatenate(all_embs, axis=0)
+
+
+def run_probe(embeddings, y, test_size=2000, random_state=42):
+    """Linear regression probe for a single parameter; handles NaN by masking.
+    Embeddings are standardized (fit on train, applied to test).
+    """
+    valid = np.isfinite(y)
+    X_v, y_v = embeddings[valid], y[valid]
+    lo, hi = np.quantile(y_v, [0.01, 0.99])
+    y_clipped = np.clip(y_v, lo, hi)
+    X_tr, X_te, y_tr, y_te = train_test_split(X_v, y_clipped, test_size=test_size,
+                                               random_state=random_state)
+    scaler = StandardScaler()
+    X_tr = scaler.fit_transform(X_tr)
+    X_te = scaler.transform(X_te)
+    probe = LinearRegression()
+    probe.fit(X_tr, y_tr)
+    y_pred = probe.predict(X_te)
+    bias = float(np.mean(y_pred - y_te))
+    r2   = r2_score(y_te, y_pred)
+    return dict(y_test=y_te, y_pred=y_pred, bias=bias, r2=r2, lo=lo, hi=hi,
+                n_train=len(X_tr), n_test=len(X_te))
+
+
+def run_probe_averaged(embeddings, y, test_size=2000, n_runs=N_PROBE_RUNS):
+    """Run probe n_runs times with different seeds; return mean/std R² and last run's full results."""
+    r2_list = []
+    last = None
+    for seed in range(n_runs):
+        pr = run_probe(embeddings, y, test_size=test_size, random_state=seed)
+        r2_list.append(pr["r2"])
+        last = pr
+    last["r2_all"]  = r2_list
+    last["r2_mean"] = float(np.mean(r2_list))
+    last["r2_std"]  = float(np.std(r2_list))
+    last["r2"]      = last["r2_mean"]   # keep backward-compat key
+    return last
+
+
+# ── 4. Compute embeddings & probes for all models ─────────────────────────────
+results = {}
+
+for size, model_name in MODELS.items():
+    print(f"\n{'='*60}")
+    print(f"Model: ConvNeXt V2 {size.capitalize()}  ({model_name})")
+    print(f"{'='*60}")
+
+    # -- Embeddings (with caching) ---------------------------------------------
+    ds_tag     = DATASET.split("/")[-1]
+    cache_path = f"{OUT_DIR}/embeddings/embeddings_{ds_tag}_convnext_{size}_{N_GALAXIES}.npy"
+    if os.path.exists(cache_path):
+        print(f"  Loading cached embeddings from {cache_path}")
+        embeddings = np.load(cache_path)
+        if len(embeddings) != len(images):
+            embeddings = embeddings[valid_idx]
+    else:
+        embeddings = compute_embeddings(images, model_name, BATCH_SIZE, DEVICE)
+        np.save(cache_path, embeddings)
+        print(f"  Saved embeddings to {cache_path}")
+    print(f"  Embeddings shape: {embeddings.shape}")
+
+    # # -- UMAP ------------------------------------------------------------------
+    # print("  Running UMAP...")
+    # reducer = umap.UMAP(n_components=2, random_state=42)
+    # coords  = reducer.fit_transform(embeddings)
+
+    # -- Probes for all physical parameters ------------------------------------
+    print(f"  Running probes ({N_PROBE_RUNS} runs each)...")
+    param_results = {}
+    for param_name, param_vals in PHYS_PARAMS.items():
+        pr = run_probe_averaged(embeddings, param_vals, test_size=5000)
+        param_results[param_name] = pr
+        print(f"    {param_name:12s}  R²={pr['r2_mean']:.4f} ± {pr['r2_std']:.4f}")
+
+    results[size] = dict(
+        embeddings=embeddings,
+        coords=None,#coords,
+        params=param_results,
+    )
+
+sizes = list(results.keys())
+
+# # ── 5. Combined UMAP figure (colored by redshift) ────────────────────────────
+# fig, axes = plt.subplots(1, len(sizes), figsize=(7 * len(sizes), 6))
+
+# for ax, size in zip(axes, sizes):
+#     r   = results[size]
+#     sc  = ax.scatter(
+#         r["coords"][:, 0], r["coords"][:, 1],
+#         c=redshift, s=10, cmap="inferno",
+#         vmin=0, vmax=4, alpha=0.8, linewidths=0,
+#     )
+#     fig.colorbar(sc, ax=ax, pad=0.02, label="Photometric redshift")
+#     ax.set_xlabel("UMAP 1", fontsize=11)
+#     ax.set_ylabel("UMAP 2", fontsize=11)
+#     ax.set_title(f"ConvNeXt V2 {size.capitalize()}", fontsize=12)
+
+# fig.suptitle(f"UMAP — {N_GALAXIES} HSC galaxies (CosmoWeb)", fontsize=13)
+# plt.tight_layout()
+# umap_path = f"{OUT_DIR}/umap_cosmosweb_convnext_{'_'.join(sizes)}_{N_GALAXIES}.png"
+# fig.savefig(umap_path, dpi=150, bbox_inches="tight")
+# plt.close(fig)
+# print(f"\nSaved UMAP figure to {umap_path}")
+
+
+# ── 6. Redshift linear probe figure (pred vs true + residuals) ───────────────
+fig, axes = plt.subplots(2, len(sizes), figsize=(7 * len(sizes), 11))
+
+for col, size in enumerate(sizes):
+    pr        = results[size]["params"]["redshift"]
+    z_test    = pr["y_test"]
+    z_pred    = pr["y_pred"]
+    bias      = pr["bias"]
+    r2        = pr["r2"]
+    residuals = z_pred - z_test
+
+    # Row 0: predicted vs true
+    ax = axes[0, col]
+    sc = ax.scatter(z_test, z_pred, c=z_test, s=15, cmap="inferno",
+                    vmin=0, vmax=4, alpha=0.7, linewidths=0)
+    fig.colorbar(sc, ax=ax, pad=0.02, label="True redshift")
+    lo = min(z_test.min(), z_pred.min())
+    hi = max(z_test.max(), z_pred.max())
+    ax.plot([lo, hi], [lo, hi], "w--", lw=1, label="1:1")
+    ax.set_xlabel("True redshift $z$", fontsize=11)
+    ax.set_ylabel("Predicted redshift $\\hat{z}$", fontsize=11)
+    ax.set_title(
+        f"ConvNeXt V2 {size.capitalize()}\n"
+        f"R²={r2:.3f}  bias={bias:+.4f}  "
+        f"(z clipped to [{pr['lo']:.3f}, {pr['hi']:.3f}])",
+        fontsize=10,
+    )
+    ax.legend(fontsize=9)
+
+    # Row 1: residual histogram
+    ax = axes[1, col]
+    ax.hist(residuals, bins=50, color="steelblue", edgecolor="none", alpha=0.85)
+    ax.axvline(0,    color="white",  lw=1.5, linestyle="--", label="zero")
+    ax.axvline(bias, color="tomato", lw=1.5, linestyle="-",
+               label=f"mean bias = {bias:+.4f}")
+    ax.set_xlabel("Residual $\\hat{z} - z$", fontsize=11)
+    ax.set_ylabel("Count", fontsize=11)
+    ax.set_title("Residual distribution", fontsize=10)
+    ax.legend(fontsize=9)
+
+n_train = results[sizes[0]]["params"]["redshift"]["n_train"]
+n_test  = results[sizes[0]]["params"]["redshift"]["n_test"]
+fig.suptitle(
+    f"Redshift linear probe — {N_GALAXIES} HSC galaxies  "
+    f"({n_train} train / {n_test} test)",
+    fontsize=13,
+)
+plt.tight_layout()
+probe_path = f"{OUT_DIR}/linear_probe_cosmosweb_convnext_{'_'.join(sizes)}_{N_GALAXIES}.png"
+fig.savefig(probe_path, dpi=150, bbox_inches="tight")
+plt.close(fig)
+print(f"Saved linear probe figure to {probe_path}")
+
+
+# ── 7. R² vs model size — one page per physical parameter in a single PDF ────
+param_names = list(PHYS_PARAMS.keys())
+x = np.arange(len(sizes))
+
+N_INDIVIDUAL = min(5, N_PROBE_RUNS)
+indiv_colors = ["#e41a1c", "#377eb8", "#4daf4a", "#ff7f00", "#984ea3"]
+
+scaling_path = f"{OUT_DIR}/scaling_linear_cosmosweb_convnext_{N_GALAXIES}.pdf"
+with PdfPages(scaling_path) as pdf:
+    for param_name in param_names:
+        r2_mean = [results[s]["params"][param_name]["r2_mean"] for s in sizes]
+        r2_std  = [results[s]["params"][param_name]["r2_std"]  for s in sizes]
+        r2_all  = [results[s]["params"][param_name]["r2_all"]  for s in sizes]
+
+        # Fit a line to R² vs model-size index for each run
+        run_slopes     = []
+        run_intercepts = []
+        for run_i in range(N_PROBE_RUNS):
+            y_vals = np.array([r2_all[si][run_i] for si in range(len(sizes))])
+            m, b = np.polyfit(x, y_vals, 1)
+            run_slopes.append(m)
+            run_intercepts.append(b)
+        mean_slope     = float(np.mean(run_slopes))
+        std_slope      = float(np.std(run_slopes))
+        mean_intercept = float(np.mean(run_intercepts))
+        std_intercept  = float(np.std(run_intercepts))
+
+        fig, ax = plt.subplots(figsize=(6, 4))
+
+        # Individual experiment runs (first N_INDIVIDUAL seeds)
+        for run_i in range(N_INDIVIDUAL):
+            y_vals = [r2_all[si][run_i] for si in range(len(sizes))]
+            ax.plot(x, y_vals, "o--", color=indiv_colors[run_i],
+                    alpha=0.55, lw=1, ms=5, label=f"run {run_i}")
+
+        # Mean ± std on top
+        ax.errorbar(x, r2_mean, yerr=r2_std, fmt="o-", color="gray",
+                    lw=2.5, ms=9, capsize=5, capthick=1.5, elinewidth=1.5,
+                    zorder=5, label="mean ± std")
+
+        # Average fitted line
+        x_fit = np.array([x[0] - 0.1, x[-1] + 0.1])
+        ax.plot(x_fit, mean_slope * x_fit + mean_intercept, "k-", lw=1.5, zorder=6,
+                label=f"fit: slope={mean_slope:.4f}±{std_slope:.4f}\n"
+                      f"     intercept={mean_intercept:.4f}±{std_intercept:.4f}")
+
+        ax.set_xticks(x)
+        ax.set_xticklabels([s.capitalize() for s in sizes], fontsize=11)
+        ax.set_xlabel("Model size", fontsize=11)
+        ax.set_ylabel("R²", fontsize=11)
+        ax.set_title(
+            f"Linear probe R² — {param_name}\n"
+            f"{N_GALAXIES} HSC galaxies  (mean ± std, {N_PROBE_RUNS} runs)",
+            fontsize=12,
+        )
+        ax.legend(fontsize=8, loc="best")
+        ax.grid(True, alpha=0.3)
+        plt.tight_layout()
+        pdf.savefig(fig)
+        plt.close(fig)
+
+print(f"Saved scaling figures to {scaling_path}")
+
+print("\nDone.")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,6 +27,10 @@ dependencies = [
 [project.optional-dependencies]
 sam2 = ["sam-2 @ git+https://github.com/facebookresearch/sam2.git"]
 aion = ["polymathic-aion"]
+cosmosweb = [
+    "matplotlib>=3.9.0",
+    "tqdm>=4.66.0",
+]
 
 [build-system]  
 requires = ["setuptools>=42", "wheel", "pybind11>=2.10"]

--- a/src/pu/metrics/neighbors.py
+++ b/src/pu/metrics/neighbors.py
@@ -4,9 +4,9 @@ Neighbor-based similarity metrics: MKNN, Jaccard, RSA.
 
 import numpy as np
 from numpy.typing import NDArray
-from sklearn.neighbors import NearestNeighbors
 from scipy.spatial.distance import pdist
-from scipy.stats import spearmanr, pearsonr
+from scipy.stats import pearsonr, spearmanr
+from sklearn.neighbors import NearestNeighbors
 
 from pu.metrics._base import validate_inputs
 
@@ -168,3 +168,26 @@ def rsa(
         raise ValueError(f"Unknown method: {method}. Use 'spearman' or 'pearson'")
 
     return float(corr)
+
+def mknn_neighbor_input(
+    nn1: NDArray[np.floating],
+    nn2: NDArray[np.floating],
+) -> float:
+    """
+    Mutual k-Nearest Neighbors overlap.
+
+    Measures the overlap between k-nearest neighbor sets in two
+    embedding spaces. 
+
+    Args:
+        nn1: (n_samples, k) neighbor matrix
+        nn2: (n_samples, k) neighbor matrix
+
+    Returns:
+        float in [0, 1] where 1 = identical neighbor sets
+
+    """
+
+    overlap = [len(set(a).intersection(b)) for a, b in zip(nn1, nn2)]
+
+    return float(np.mean(overlap) / nn1.shape[1])

--- a/src/pu/metrics/physics.py
+++ b/src/pu/metrics/physics.py
@@ -13,20 +13,19 @@ predict physical galaxy properties — and larger models should do so better.
 Requires: Smith42/galaxies (revision v2.0) which bundles metadata directly.
 """
 
+
 import numpy as np
 from numpy.typing import NDArray
-from typing import Any
-
-from sklearn.decomposition import PCA
-from sklearn.linear_model import LinearRegression
-from sklearn.ensemble import GradientBoostingRegressor
-from sklearn.metrics import r2_score
-from sklearn.model_selection import cross_val_score, KFold
-from sklearn.neighbors import NearestNeighbors
-from sklearn.preprocessing import StandardScaler
 from scipy.spatial.distance import pdist
 from scipy.stats import spearmanr
-
+from scipy.stats import wasserstein_distance as w_d
+from sklearn.decomposition import PCA
+from sklearn.ensemble import GradientBoostingRegressor
+from sklearn.linear_model import LinearRegression
+from sklearn.metrics import r2_score
+from sklearn.model_selection import KFold, cross_val_score
+from sklearn.neighbors import NearestNeighbors
+from sklearn.preprocessing import StandardScaler
 
 # ---------------------------------------------------------------------------
 # Canonical physical properties to probe, grouped by science domain.
@@ -555,3 +554,26 @@ def _clean_inputs(
         raise ValueError("No valid samples after removing NaN/Inf")
 
     return Z, y
+
+
+def wass_distance(
+    nn1,
+    nn2,
+    params,
+):
+    """
+    Wasserstein distance calculated between physical parameters distributions in two embedding spaces.
+
+    Args:
+        nn1: (n_samples, n_neighbors) neighbor matrix in first embedding space. Values are indices that correspond to param array.
+        nn2: (n_samples, n_neighbors) neighbor matrix in second embedding space. Values are indices that correspond to param array.
+        params: np.array of physical parameters.
+
+    Returns:
+        Average wasserstein distance.
+    """
+
+    w_ds = [w_d(params[nn1[idx]], params[nn2[idx]]) for idx in range(nn1.shape[0])]
+    return w_ds
+
+    

--- a/src/pu/pu_datasets/__init__.py
+++ b/src/pu/pu_datasets/__init__.py
@@ -1,11 +1,13 @@
-from .registry import register_dataset, get_dataset_adapter, list_datasets
-
 # Import adapters so they register themselves on package import.
 # These imports are unused directly but trigger registration side-effects.
-from . import hf_crossmatched  # noqa: F401
-from . import sdss  # noqa: F401
-from . import desi  # noqa: F401
-from . import galaxies  # noqa: F401
-from . import desi_spectra  # noqa: F401
+from . import (
+    cosmosweb,  # noqa: F401
+    desi,  # noqa: F401
+    desi_spectra,  # noqa: F401
+    galaxies,  # noqa: F401
+    hf_crossmatched,  # noqa: F401
+    sdss,  # noqa: F401
+)
+from .registry import get_dataset_adapter, list_datasets, register_dataset
 
 __all__ = ["register_dataset", "get_dataset_adapter", "list_datasets"]

--- a/src/pu/pu_datasets/cosmosweb.py
+++ b/src/pu/pu_datasets/cosmosweb.py
@@ -1,0 +1,42 @@
+from typing import Callable, Iterable
+
+from datasets import load_dataset
+
+from pu.pu_datasets.base import DatasetAdapter
+from pu.pu_datasets.registry import register_dataset
+
+# Maps physics parameter name → dataset column name for Ashodkh/cosmosweb-hsc-jwst-high-snr-pil2.
+CATALOG_COLUMNS = {
+    "redshift": "lephare_photozs",
+    "mag_g":    "mag_model_hsc-g",
+    "mag_r":    "mag_model_hsc-r",
+    "mass":     "lp_mass",
+    "sSFR":     "lp_ssfr",
+}
+
+
+class CosmosWebAdapter(DatasetAdapter):
+    """Adapter for Ashodkh/cosmosweb-hsc-jwst-high-snr-pil2.
+
+    comp_mode selects the telescope band: "hsc" or "jwst".
+    Image column convention: {comp_mode}_images.
+    """
+
+    def load(self) -> None:
+        return None
+
+    def prepare(self, processor: Callable, modes: Iterable[str], filterfun: Callable):
+        image_cols = [f"{mode}_images" for mode in modes]
+        ds = (
+            load_dataset(self.hf_ds, split="train", streaming=True)
+            .select_columns(image_cols)
+            .filter(filterfun)
+            .map(processor)
+            .remove_columns(image_cols)
+        )
+        if hasattr(ds, "with_format"):
+            ds = ds.with_format("torch")
+        return ds
+
+
+register_dataset("cosmosweb", CosmosWebAdapter)


### PR DESCRIPTION
Cherry-picks the reusable parts of #58 into core and moves the experiment scripts into `experiments/cosmosweb/` as an optional install. The five experiment scripts are byte-identical to the originals; the package surface only gains additive functions.

Closes #58.

## Equivalence proof

### A. Scripts are byte-identical to #58 originals

```
$ for pair in src/pu/cosmosweb_physics_experiment_pu.py:experiments/cosmosweb/run_intramodal.py ... ; do
    h1=$(git show pr58:$src | sha256sum); h2=$(sha256sum $dst); ...
  done
  IDENTICAL  1915fa76dbed  run_intramodal.py
  IDENTICAL  9e1310f8e931  run_crossmodal.py
  IDENTICAL  9eff37484af9  probe_weight_analysis.py
  IDENTICAL  4c9c7f33434c  plot_mknn_vs_r2.py
  IDENTICAL  467127055ad1  test_linear_probe.py
```

### B. All moved scripts compile cleanly

```
$ for f in experiments/cosmosweb/*.py; do python -m py_compile "$f"; done
  OK  experiments/cosmosweb/plot_mknn_vs_r2.py
  OK  experiments/cosmosweb/probe_weight_analysis.py
  OK  experiments/cosmosweb/run_crossmodal.py
  OK  experiments/cosmosweb/run_intramodal.py
  OK  experiments/cosmosweb/test_linear_probe.py
```

### C. Imports the scripts depend on resolve from core

```
$ python -c "..."
  OK  import pu.pu_datasets.cosmosweb
  OK  import pu.metrics.physics
  OK  import pu.metrics.neighbors
  OK  CATALOG_COLUMNS, CosmosWebAdapter
  OK  wass_distance
  OK  mknn_neighbor_input
  OK  cosmosweb registered (datasets: ['cosmosweb', 'desi', 'desi_spectra', 'galaxies', 'jwst', 'legacysurvey', 'sdss'])
```

### D. Existing metrics test suite still passes

```
$ pytest tests/test_metrics_kernel.py tests/test_metrics_neighbors.py tests/test_metrics_spectral.py -q
................................................................         [100%]
64 passed in 1.16s
```

### E. Core diff is purely additive — no functions removed or modified semantically

```
 src/pu/metrics/neighbors.py     | 27 ++++++++++++++++++++++++--
 src/pu/metrics/physics.py       | 36 ++++++++++++++++++++++++++++-------
 src/pu/pu_datasets/__init__.py  | 16 +++++++++-------
 src/pu/pu_datasets/cosmosweb.py | 42 +++++++++++++++++++++++++++++++++++++++++
 4 files changed, 105 insertions(+), 16 deletions(-)
```

## Equivalence of run commands

| #58 | This PR |
|---|---|
| `python src/pu/cosmosweb_physics_experiment_pu.py` | `python experiments/cosmosweb/run_intramodal.py` |
| `python src/pu/cosmosweb_physics_experiment_pu_cross_modal.py` | `python experiments/cosmosweb/run_crossmodal.py` |
| `python src/pu/cosmosweb_probe_weight_analysis.py` | `python experiments/cosmosweb/probe_weight_analysis.py` |
| `python src/pu/plot_avg_mknn_vs_r2.py` | `python experiments/cosmosweb/plot_mknn_vs_r2.py` |
| `pytest tests/test_linear_probe_cosmosweb_convnext.py` | `pytest experiments/cosmosweb/test_linear_probe.py` |

Imports inside the scripts are unchanged (`from pu.pu_datasets.cosmosweb import ...`, `from pu.metrics.physics import wass_distance`, `from pu.metrics.neighbors import mknn_neighbor_input`).

## What's where

**Core (~90 net lines, additive only)**
- `pu_datasets/cosmosweb.py` — registry-style adapter
- `metrics/physics.py` — adds `wass_distance`
- `metrics/neighbors.py` — adds `mknn_neighbor_input`

**`experiments/cosmosweb/` (~2500 lines, optional install)**
- All four `cosmosweb_*.py` scripts plus `plot_mknn_vs_r2.py` and the convnext linear-probe test, byte-identical to #58. Activated by `uv pip install ".[cosmosweb]"`.

**Not taken**
- CLAUDE.md changes (unrelated docs rewrite — main has a different version).