### PR TITLE
feat(platonic/regress): permutation p-values, pairwise MKNN/Wasserstein, UMAP

### DIFF
--- a/experiments/platonic/regress/README.md
+++ b/experiments/platonic/regress/README.md
@@ -65,12 +65,34 @@ The JSON layout matches what's consumed by Smith42's plotting branch:
 
 ```
 experiments/platonic/regress/
-├── pu_regress.py     worker: claim → extract → probe → upload → release
-├── setup_hf.py       one-time bootstrap of the coordination dataset
-├── aggregate.py      pull all done/*.parquet -> one summary parquet (+ optional JSON)
-├── slurm/            SBATCH wrapper
-└── vast/             tmux launcher (one worker per GPU)
+├── pu_regress.py        worker: claim → extract → probe → kNN → UMAP → upload → release
+├── pu_regress_pairs.py  aggregator: pulls all neighbour matrices,
+│                        computes intramodal + crossmodal MKNN + Wasserstein
+├── setup_hf.py          one-time bootstrap of the coordination dataset
+├── aggregate.py         pull all done/*.parquet -> one summary parquet (+ optional JSON)
+├── slurm/               SBATCH wrapper
+└── vast/                tmux launcher (one worker per GPU)
 ```
+
+## Per-tuple output files
+
+Each completed `(modality, alias, size)` tuple uploads three parquets to
+`done/<tag>/` on the coordination dataset:
+
+| File | Per-row contents |
+|---|---|
+| `probe.parquet` | one row per physical property: $R^2$ mean, $R^2$ std, permutation $p$-value, sample sizes, hyperparams |
+| `neighbours.parquet` | one row per galaxy: the $(k,)$ integer indices of its $k$ nearest neighbours in this tuple's embedding space |
+| `umap.parquet` | one row per galaxy: 2-D UMAP coordinates from a precomputed kNN graph (cosine, $k = 50$) |
+
+The `pairs.parquet` produced by `pu_regress_pairs.py` consumes all the
+`neighbours.parquet` files plus a re-streamed catalog and produces:
+
+| Column | Meaning |
+|---|---|
+| `pair_kind` | `intramodal` (adjacent sizes within a family on the same modality) or `crossmodal` (HSC vs JWST of the same model size) |
+| `mknn` | mean per-row $|\mathcal N_a \cap \mathcal N_b| / k$ |
+| `wass_<property>` | mean per-row Wasserstein-1 distance between the two sides' physics-label distributions on their kNN sets |
 
 ## Cost
 

--- a/experiments/platonic/regress/pu_regress.py
+++ b/experiments/platonic/regress/pu_regress.py
@@ -24,6 +24,8 @@ Optional environment:
     PU_REGRESS_BATCH_SIZE       default 16
     PU_REGRESS_CV_FOLDS         default 5
     PU_REGRESS_PCA_COMPONENTS   default 0 (disabled)
+    PU_REGRESS_N_PERM           default 100; permutation reps for p-value
+    PU_REGRESS_KNN_K            default 10; k for the per-tuple kNN graph
     PU_REGRESS_STALE_S          default 3600 (1 h)
     PU_REGRESS_TARGET           e.g. "hsc/dino_giant" — single-tuple mode
 """
@@ -64,6 +66,8 @@ N_USE      = int(os.environ.get("PU_REGRESS_N_USE", "45000"))
 BATCH_SIZE = int(os.environ.get("PU_REGRESS_BATCH_SIZE", "16"))
 CV_FOLDS   = int(os.environ.get("PU_REGRESS_CV_FOLDS", "5"))
 PCA_K      = int(os.environ.get("PU_REGRESS_PCA_COMPONENTS", "0")) or None
+N_PERM     = int(os.environ.get("PU_REGRESS_N_PERM", "100"))
+KNN_K      = int(os.environ.get("PU_REGRESS_KNN_K", "10"))
 STALE_S    = int(os.environ.get("PU_REGRESS_STALE_S", "3600"))
 TARGET     = os.environ.get("PU_REGRESS_TARGET", "")  # single-tuple mode
 
@@ -130,10 +134,28 @@ def tag_for(modality: str, alias: str, size: str) -> str:
 # HF claim / release coordination
 # ---------------------------------------------------------------------------
 def hf_list_state() -> tuple[set[str], dict[str, datetime]]:
-    """Return (done_tags, running_tag -> last_modified)."""
+    """Return (done_tags, running_tag -> last_modified).
+
+    A tag is 'done' iff both done/<tag>/probe.parquet and
+    done/<tag>/neighbours.parquet are present on the dataset (legacy single-
+    file done/<tag>.parquet entries are also accepted for back-compat with
+    the pre-pairs layout).
+    """
     files = api.list_repo_files(COORD_REPO, repo_type="dataset")
-    done = {f.replace("done/", "").replace(".parquet", "")
-            for f in files if f.startswith("done/") and f.endswith(".parquet")}
+    done_legacy = {f.replace("done/", "").replace(".parquet", "")
+                   for f in files
+                   if f.startswith("done/") and f.endswith(".parquet")
+                   and "/" not in f.replace("done/", "")}
+    # New folder layout: done/<tag>/{probe,neighbours}.parquet
+    by_tag: dict[str, set[str]] = {}
+    for f in files:
+        if f.startswith("done/") and "/" in f[len("done/"):] and f.endswith(".parquet"):
+            tag = f[len("done/"):].split("/", 1)[0]
+            leaf = f[len("done/"):].split("/", 1)[1]
+            by_tag.setdefault(tag, set()).add(leaf)
+    done_new = {tag for tag, leaves in by_tag.items()
+                if {"probe.parquet", "neighbours.parquet"}.issubset(leaves)}
+    done = done_legacy | done_new
     running_tags = {f.replace("running/", "").replace(".running", "")
                     for f in files
                     if f.startswith("running/") and f.endswith(".running")}
@@ -371,26 +393,116 @@ def extract_embeddings(alias: str, size: str, hf_id: str,
 # ---------------------------------------------------------------------------
 # Per-tuple regression
 # ---------------------------------------------------------------------------
+def _probe_with_pvalue(Z: np.ndarray, y: np.ndarray
+                       ) -> tuple[float, float, float]:
+    """Returns (r2_mean, r2_std, p_value) where p is the one-sided
+    permutation-test p-value for H0: no linear relationship between Z and y.
+    Uses N_PERM shuffles of y, refits the same CV pipeline."""
+    res = linear_probe(Z, y, cv=CV_FOLDS, pca_components=PCA_K)
+    if isinstance(res, dict):
+        observed = float(res.get("mean", float("nan")))
+        std      = float(res.get("std",  float("nan")))
+    else:
+        observed, std = float(res), float("nan")
+    if N_PERM <= 0 or not np.isfinite(observed):
+        return observed, std, float("nan")
+    rng = np.random.default_rng(0)
+    null = []
+    for _ in range(N_PERM):
+        y_perm = rng.permutation(y)
+        rp = linear_probe(Z, y_perm, cv=CV_FOLDS, pca_components=PCA_K)
+        rp_mean = rp["mean"] if isinstance(rp, dict) else rp
+        null.append(float(rp_mean))
+    null_arr = np.asarray(null)
+    # Phipson-Smyth correction so p > 0 always.
+    p_value = (1 + int(np.sum(null_arr >= observed))) / (N_PERM + 1)
+    return observed, std, float(p_value)
+
+
+def _build_knn(Z: np.ndarray, k: int) -> tuple[np.ndarray, np.ndarray]:
+    """Per-row kNN indices + cosine distances (excluding self).
+    Returns (idx, dist) where idx is (n, k) int32 and dist is (n, k) float32.
+    Uses faiss if available, else sklearn."""
+    Zc = np.ascontiguousarray(Z, dtype=np.float32)
+    Zc /= (np.linalg.norm(Zc, axis=1, keepdims=True) + 1e-12)
+    try:
+        import faiss
+        d = Zc.shape[1]
+        index = faiss.IndexFlatIP(d)
+        index.add(Zc)
+        sim, idx = index.search(Zc, k + 1)
+        # cosine distance = 1 - inner-product similarity (since vectors are unit-norm)
+        dist = (1.0 - sim).astype(np.float32)
+        return idx[:, 1:].astype(np.int32), dist[:, 1:]
+    except Exception:
+        from sklearn.neighbors import NearestNeighbors
+        nn = NearestNeighbors(n_neighbors=k + 1, metric="cosine").fit(Zc)
+        dist, idx = nn.kneighbors(return_distance=True)
+        return idx[:, 1:].astype(np.int32), dist[:, 1:].astype(np.float32)
+
+
+def _umap_2d(Z: np.ndarray, idx: np.ndarray, dist: np.ndarray,
+             k: int) -> np.ndarray | None:
+    """Run UMAP using a precomputed kNN graph. Returns (n, 2) float32 or
+    None if umap-learn isn't installed (in which case the worker still
+    succeeds, just no umap.parquet is uploaded)."""
+    try:
+        import umap
+    except Exception:
+        return None
+    Zn = Z / (np.linalg.norm(Z, axis=1, keepdims=True) + 1e-12)
+    emb2d = umap.UMAP(
+        n_neighbors=k, metric="cosine",
+        precomputed_knn=(idx, dist, None),
+        random_state=0, n_epochs=200,
+    ).fit_transform(Zn)
+    return emb2d.astype(np.float32)
+
+
 def regress_tuple(alias: str, size: str, hf_id: str, params_M: int,
-                  modality: str, catalog: dict[str, np.ndarray]) -> pl.DataFrame:
+                  modality: str, catalog: dict[str, np.ndarray]
+                  ) -> tuple[pl.DataFrame, pl.DataFrame, pl.DataFrame | None]:
+    """Returns (probe_df, neighbors_df, umap_df).
+
+    probe_df has one row per physics property: R² mean + std + permutation p-value.
+    neighbors_df has one row per galaxy: the (k,) integer indices of its k
+    nearest neighbours in this tuple's embedding space.
+    umap_df has one row per galaxy: 2-D UMAP coords (or None if umap-learn
+    isn't available).
+    """
     Z = extract_embeddings(alias, size, hf_id, modality, N_USE)
+
+    log(f"  building cosine kNN graph (k={KNN_K})")
+    nn_idx, nn_dist = _build_knn(Z, KNN_K)
+    nn_df = pl.DataFrame({
+        "galaxy_idx":  np.arange(len(Z), dtype=np.int32),
+        "neighbours":  pl.Series(
+            "neighbours",
+            nn_idx,
+            dtype=pl.Array(pl.Int32, KNN_K),
+        ),
+    })
+
+    log("  computing UMAP-2D (precomputed kNN)")
+    emb2d = _umap_2d(Z, nn_idx, nn_dist, KNN_K)
+    umap_df = None
+    if emb2d is not None:
+        umap_df = pl.DataFrame({
+            "galaxy_idx": np.arange(len(Z), dtype=np.int32),
+            "umap_x":     emb2d[:, 0],
+            "umap_y":     emb2d[:, 1],
+        })
+
     rows = []
     for prop, y in catalog.items():
         n = min(len(Z), len(y))
         try:
-            res = linear_probe(Z[:n], y[:n], cv=CV_FOLDS, pca_components=PCA_K)
-            # linear_probe declares -> float but actually returns
-            # {"mean": ..., "std": ..., "folds": [...]}. Be defensive in case
-            # that contract gets fixed upstream.
-            if isinstance(res, dict):
-                r2_mean = float(res.get("mean", float("nan")))
-                r2_std  = float(res.get("std",  float("nan")))
-            else:
-                r2_mean, r2_std = float(res), float("nan")
+            r2_mean, r2_std, p_val = _probe_with_pvalue(Z[:n], y[:n])
         except Exception as e:
             log(f"    {prop}: probe failed: {type(e).__name__}: {e}")
-            r2_mean, r2_std = float("nan"), float("nan")
-        log(f"    R²({prop}) = {r2_mean:.4f} ± {r2_std:.4f}")
+            r2_mean, r2_std, p_val = float("nan"), float("nan"), float("nan")
+        log(f"    R²({prop}) = {r2_mean:.4f} ± {r2_std:.4f}  "
+            f"p={p_val:.4f}")
         rows.append({
             "modality": modality,
             "model_alias": alias,
@@ -400,12 +512,14 @@ def regress_tuple(alias: str, size: str, hf_id: str, params_M: int,
             "property": prop,
             "r2_mean": r2_mean,
             "r2_std":  r2_std,
+            "r2_pvalue": p_val,
             "n": int(n),
             "d": int(Z.shape[1]),
             "cv_folds": CV_FOLDS,
             "pca_k": PCA_K or 0,
+            "n_perm": N_PERM,
         })
-    return pl.DataFrame(rows)
+    return pl.DataFrame(rows), nn_df, umap_df
 
 
 # ---------------------------------------------------------------------------
@@ -456,18 +570,38 @@ def main() -> int:
         try:
             if catalog is None:
                 catalog = collect_catalog(N_USE)
-            df = regress_tuple(alias, size, hf_id, params_M, modality, catalog)
-            tmp = OUT_DIR / f"{tag}.parquet.tmp.{os.getpid()}"
-            final = OUT_DIR / f"{tag}.parquet"
-            df.write_parquet(tmp, compression="zstd")
-            os.rename(tmp, final)
-            api.upload_file(
-                path_or_fileobj=str(final),
-                path_in_repo=f"done/{tag}.parquet",
-                repo_id=COORD_REPO, repo_type="dataset",
-                commit_message=f"done {tag}",
+            probe_df, nn_df, umap_df = regress_tuple(
+                alias, size, hf_id, params_M, modality, catalog,
             )
-            log(f"[done] {tag} -> done/{tag}.parquet")
+            # Stage parquets into a per-tag folder, then upload as one
+            # commit via upload_folder (cuts HF commit volume vs uploading
+            # files separately).
+            tag_dir = OUT_DIR / tag
+            tag_dir.mkdir(exist_ok=True)
+            probe_path = tag_dir / "probe.parquet"
+            nn_path    = tag_dir / "neighbours.parquet"
+            probe_df.write_parquet(probe_path, compression="zstd")
+            nn_df.write_parquet(nn_path, compression="zstd")
+            if umap_df is not None:
+                umap_path = tag_dir / "umap.parquet"
+                umap_df.write_parquet(umap_path, compression="zstd")
+            import shutil
+            staging = OUT_DIR / f".upload_{tag}_{os.getpid()}"
+            (staging / f"done/{tag}").mkdir(parents=True, exist_ok=True)
+            shutil.copy2(probe_path, staging / f"done/{tag}/probe.parquet")
+            shutil.copy2(nn_path,    staging / f"done/{tag}/neighbours.parquet")
+            if umap_df is not None:
+                shutil.copy2(umap_path, staging / f"done/{tag}/umap.parquet")
+            try:
+                api.upload_folder(
+                    folder_path=str(staging),
+                    repo_id=COORD_REPO, repo_type="dataset",
+                    commit_message=f"done {tag}",
+                )
+            finally:
+                shutil.rmtree(staging, ignore_errors=True)
+            log(f"[done] {tag} -> done/{tag}/"
+                f"{{probe,neighbours{'' if umap_df is None else ',umap'}}}.parquet")
         except KeyboardInterrupt:
             release_claim(tag)
             raise

--- a/experiments/platonic/regress/pu_regress_pairs.py
+++ b/experiments/platonic/regress/pu_regress_pairs.py
@@ -1,0 +1,295 @@
+#!/usr/bin/env python3
+"""Pairwise MKNN + Wasserstein on the per-tuple kNN graphs uploaded by
+pu_regress.py.
+
+Two pair families are computed (matching Ashod's pipeline):
+
+  Intramodal — adjacent model sizes within the same family on the same
+               modality. Tests whether scaling preserves representation
+               structure.
+                 e.g. (hsc, vit/base)   vs (hsc, vit/large)
+                      (hsc, vit/large)  vs (hsc, vit/huge)
+
+  Crossmodal — same model size, both modalities. Tests whether the
+               model's HSC and JWST embeddings agree on which galaxies
+               are nearest neighbours.
+                 e.g. (hsc, dino_giant) vs (jwst, dino_giant)
+
+For each pair we compute:
+  - MKNN overlap (mean fraction of shared neighbours)
+  - Wasserstein-1 distance between the physics-label distributions
+    sampled from each side's nearest-neighbour set, per property,
+    averaged over galaxies
+
+Output: one summary parquet with one row per (pair_kind, group, ...) entry.
+
+Usage:
+    python pu_regress_pairs.py \\
+        --pull-from <owner>/pu-regress-results \\
+        --out-dir   /path/to/derived
+        [--upload-to <owner>/pu-regress-results]   # writes summary.pairs.parquet under done/
+"""
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+from pathlib import Path
+
+import numpy as np
+import polars as pl
+
+# ---------------------------------------------------------------------------
+# Adjacent-size pairs per family. Has to match pu_regress.MODEL_GRID order.
+# Hardcoded here to keep this script self-contained; a deviation would be
+# obvious as a missing pair in the output.
+# ---------------------------------------------------------------------------
+FAMILY_SIZES = {
+    "vit":       ["base", "large", "huge"],
+    "clip":      ["base", "large"],
+    "dinov3":    ["vits16", "vits16plus", "vitb16", "vitl16", "vith16plus", "vit7b16"],
+    "convnext":  ["nano", "tiny", "base", "large"],
+    "ijepa":     ["huge", "giant"],
+    "vjepa":     ["large", "huge", "giant"],
+    "astropt":   ["015M", "095M", "850M"],
+    "vit-mae":   ["base", "large", "huge"],
+    "paligemma": ["3b", "10b", "28b"],
+    "llava_15":  ["7b", "13b"],
+}
+MODALITIES = ("hsc", "jwst")
+
+# Set of (modality, alias, size) tuples whose probe files we'll read.
+ALL_TUPLES = [
+    (m, alias, size)
+    for m in MODALITIES
+    for alias, sizes in FAMILY_SIZES.items()
+    for size in sizes
+]
+
+
+def parse_args() -> argparse.Namespace:
+    p = argparse.ArgumentParser(__doc__)
+    p.add_argument("--pull-from", default=os.environ.get("PU_REGRESS_RESULTS_REPO"))
+    p.add_argument("--out-dir", type=Path, required=True)
+    p.add_argument("--upload-to", default=None,
+                   help="If set, upload the summary parquet here under done/summary.pairs.parquet.")
+    p.add_argument("--cache-dir", type=Path, default=None,
+                   help="Where to keep pulled per-tuple parquets (default: $out_dir/_regress_cache).")
+    return p.parse_args()
+
+
+def fetch_all(repo: str, dest: Path, token: str | None) -> Path:
+    from huggingface_hub import HfApi, hf_hub_download
+    api = HfApi(token=token)
+    files = [f for f in api.list_repo_files(repo, repo_type="dataset")
+             if f.startswith("done/") and f.endswith(".parquet")]
+    if not files:
+        raise SystemExit(f"[fatal] no done/*.parquet on {repo}")
+    print(f"pulling {len(files)} files from {repo}")
+    dest.mkdir(parents=True, exist_ok=True)
+    for f in files:
+        hf_hub_download(repo, f, repo_type="dataset",
+                        local_dir=str(dest), token=token)
+    return dest / "done"
+
+
+def load_neighbours(done_dir: Path, tag: str) -> np.ndarray | None:
+    p = done_dir / tag / "neighbours.parquet"
+    if not p.exists():
+        return None
+    df = pl.read_parquet(p)
+    arr = np.array(df["neighbours"].to_list(), dtype=np.int32)
+    return arr
+
+
+def load_probe(done_dir: Path, tag: str) -> pl.DataFrame | None:
+    p = done_dir / tag / "probe.parquet"
+    if not p.exists():
+        return None
+    return pl.read_parquet(p)
+
+
+def reconstruct_catalog_from_probes(done_dir: Path) -> dict[str, np.ndarray] | None:
+    """Pulls one probe parquet to learn the catalog row count and properties,
+    then reconstructs the per-galaxy parameter arrays by streaming the source
+    dataset (this is unavoidable — physics labels themselves aren't uploaded
+    per tuple, only the kNN indices into the catalog).
+    """
+    # pick the first probe parquet we can find
+    for tag_dir in done_dir.iterdir():
+        if (tag_dir / "probe.parquet").exists():
+            df = pl.read_parquet(tag_dir / "probe.parquet")
+            n = int(df["n"][0])
+            break
+    else:
+        return None
+
+    # Stream the source dataset to recover labels (same logic as pu_regress).
+    from datasets import load_dataset
+
+    from pu.pu_datasets.cosmosweb import CATALOG_COLUMNS
+    DATASET = os.environ.get(
+        "PU_REGRESS_DATASET",
+        "Ashodkh/cosmosweb-hsc-jwst-high-snr-pil2",
+    )
+    print(f"reconstructing catalog (N={n}) from {DATASET}")
+    ds = load_dataset(DATASET, split="train", streaming=True)
+    cols = list(CATALOG_COLUMNS.values())
+    raw = {c: [] for c in cols}
+    for i, row in enumerate(ds):
+        for c in cols:
+            raw[c].append(row[c])
+        if i + 1 >= n:
+            break
+    out = {param: np.asarray(raw[col], dtype=np.float32)
+           for param, col in CATALOG_COLUMNS.items()}
+    out["g-r"] = out["mag_g"] - out["mag_r"]
+    return out
+
+
+def mknn_overlap(nn1: np.ndarray, nn2: np.ndarray) -> float:
+    """Mean per-row fraction |N1 ∩ N2| / k. Same metric as
+    pu.metrics.neighbors.mknn_neighbor_input."""
+    k = nn1.shape[1]
+    overlap = [len(set(a).intersection(b)) for a, b in zip(nn1, nn2)]
+    return float(np.mean(overlap) / k)
+
+
+def wasserstein_per_property(nn1: np.ndarray, nn2: np.ndarray,
+                             y: np.ndarray) -> float:
+    """Per-row W1 between {y[N1(i)]} and {y[N2(i)]}, averaged. Same as
+    pu.metrics.physics.wass_distance."""
+    from scipy.stats import wasserstein_distance as w_d
+    n = nn1.shape[0]
+    finite = np.isfinite(y)
+    if not finite.any():
+        return float("nan")
+    y = np.where(finite, y, np.nan)
+    vals = []
+    for i in range(n):
+        s1 = y[nn1[i]]
+        s2 = y[nn2[i]]
+        s1 = s1[np.isfinite(s1)]
+        s2 = s2[np.isfinite(s2)]
+        if len(s1) == 0 or len(s2) == 0:
+            continue
+        vals.append(w_d(s1, s2))
+    return float(np.mean(vals)) if vals else float("nan")
+
+
+def main() -> int:
+    args = parse_args()
+    if not args.pull_from:
+        print("[fatal] --pull-from required (or set $PU_REGRESS_RESULTS_REPO)",
+              file=sys.stderr)
+        return 2
+
+    args.out_dir.mkdir(parents=True, exist_ok=True)
+    cache = args.cache_dir or (args.out_dir / "_regress_cache")
+    done_dir = fetch_all(args.pull_from, cache, os.environ.get("HF_TOKEN"))
+
+    catalog = reconstruct_catalog_from_probes(done_dir)
+    if catalog is None:
+        print("[fatal] no probe parquet found in cache", file=sys.stderr)
+        return 1
+
+    # Cache loaded neighbour matrices once.
+    nn_cache: dict[tuple[str, str, str], np.ndarray] = {}
+    for modality, alias, size in ALL_TUPLES:
+        tag = f"{modality}__{alias}_{size}"
+        n = load_neighbours(done_dir, tag)
+        if n is not None:
+            nn_cache[(modality, alias, size)] = n
+
+    print(f"loaded {len(nn_cache)}/{len(ALL_TUPLES)} neighbour matrices")
+    rows = []
+
+    # ---- Intramodal: adjacent sizes within a family ----
+    for modality in MODALITIES:
+        for alias, sizes in FAMILY_SIZES.items():
+            for s1, s2 in zip(sizes, sizes[1:]):
+                t1 = (modality, alias, s1)
+                t2 = (modality, alias, s2)
+                if t1 not in nn_cache or t2 not in nn_cache:
+                    continue
+                nn1 = nn_cache[t1]
+                nn2 = nn_cache[t2]
+                nrow = min(len(nn1), len(nn2))
+                nn1c, nn2c = nn1[:nrow], nn2[:nrow]
+                row = {
+                    "pair_kind":   "intramodal",
+                    "modality_a":  modality,
+                    "modality_b":  modality,
+                    "model_alias": alias,
+                    "size_a":      s1,
+                    "size_b":      s2,
+                    "n":           int(nrow),
+                    "k":           int(nn1.shape[1]),
+                    "mknn":        mknn_overlap(nn1c, nn2c),
+                }
+                for prop, y in catalog.items():
+                    row[f"wass_{prop}"] = wasserstein_per_property(
+                        nn1c, nn2c, y[:nrow])
+                rows.append(row)
+
+    # ---- Crossmodal: same model size, both modalities ----
+    for alias, sizes in FAMILY_SIZES.items():
+        for size in sizes:
+            t_h = ("hsc",  alias, size)
+            t_j = ("jwst", alias, size)
+            if t_h not in nn_cache or t_j not in nn_cache:
+                continue
+            nn1 = nn_cache[t_h]
+            nn2 = nn_cache[t_j]
+            nrow = min(len(nn1), len(nn2))
+            nn1c, nn2c = nn1[:nrow], nn2[:nrow]
+            row = {
+                "pair_kind":   "crossmodal",
+                "modality_a":  "hsc",
+                "modality_b":  "jwst",
+                "model_alias": alias,
+                "size_a":      size,
+                "size_b":      size,
+                "n":           int(nrow),
+                "k":           int(nn1.shape[1]),
+                "mknn":        mknn_overlap(nn1c, nn2c),
+            }
+            for prop, y in catalog.items():
+                row[f"wass_{prop}"] = wasserstein_per_property(
+                    nn1c, nn2c, y[:nrow])
+            rows.append(row)
+
+    if not rows:
+        print("[fatal] no pairs computed (no neighbour matrices loaded?)",
+              file=sys.stderr)
+        return 1
+
+    df = pl.DataFrame(rows)
+    out_pq = args.out_dir / "regress_pairs.parquet"
+    df.write_parquet(out_pq, compression="zstd")
+    print(f"wrote {out_pq}  ({len(df)} pairs)")
+    print()
+    summary = (df.group_by("pair_kind")
+                  .agg([pl.col("mknn").mean().alias("mknn_mean"),
+                        pl.col("mknn").min().alias("mknn_min"),
+                        pl.col("mknn").max().alias("mknn_max"),
+                        pl.len().alias("n_pairs")]))
+    print(summary)
+
+    if args.upload_to:
+        from huggingface_hub import HfApi
+        api = HfApi(token=os.environ.get("HF_TOKEN"))
+        api.upload_file(
+            path_or_fileobj=str(out_pq),
+            path_in_repo="done/summary.pairs.parquet",
+            repo_id=args.upload_to,
+            repo_type="dataset",
+            commit_message="pu_regress_pairs: refresh pairwise summary",
+        )
+        print(f"uploaded -> {args.upload_to}/done/summary.pairs.parquet")
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,6 +46,10 @@ platonic-regress = [
     "huggingface-hub>=0.20.0",
     "tqdm>=4.66.0",
     "matplotlib>=3.9.0",
+    "umap-learn>=0.5.0",
+    "pynndescent>=0.5.0",
+    "faiss-cpu>=1.8.0",
+    "scipy>=1.10.0",
 ]
 
 [build-system]  


### PR DESCRIPTION
Adds the rest of Ashod's pipeline to \`experiments/platonic/regress/\`, plus a real significance test on the linear probes and UMAP coords ready for plotting.

## What's new

| Addition | Where |
|---|---|
| Permutation p-value on each linear probe (Phipson–Smyth corrected) | per-tuple, in \`pu_regress.py\` |
| Per-tuple cosine kNN graph (faiss, k=10 by default) | per-tuple, saved as \`done/<tag>/neighbours.parquet\` |
| Per-tuple UMAP-2D using the precomputed kNN graph | per-tuple, saved as \`done/<tag>/umap.parquet\` |
| Pairwise **MKNN overlap** between embeddings (intramodal + crossmodal) | new aggregator \`pu_regress_pairs.py\` |
| Pairwise **Wasserstein distance** per physics property | new aggregator \`pu_regress_pairs.py\` |

## Per-tuple output schema

\`done/<tag>/\` now contains three parquets uploaded as one \`upload_folder\` commit:

- \`probe.parquet\` — one row per property: \`r2_mean, r2_std, r2_pvalue, n, d, cv_folds, pca_k, n_perm\`
- \`neighbours.parquet\` — one row per galaxy: \`(k,)\` int32 indices in this embedding space
- \`umap.parquet\` — one row per galaxy: \`umap_x, umap_y\` (precomputed-kNN UMAP, cosine)

## Pairwise output schema

\`pu_regress_pairs.py\` pulls every neighbour matrix from HF and computes:

- **Intramodal:** adjacent sizes within a family on the same modality (e.g., \`(hsc, vit-base)\` vs \`(hsc, vit-large)\`).
- **Crossmodal:** \`(hsc, model_size)\` vs \`(jwst, model_size)\`.

Each pair gets one row with: \`pair_kind, modality_a/b, model_alias, size_a/b, n, k, mknn\` plus \`wass_<property>\` for each of the 6 physical labels.

## Mapping to Ashod's pipeline

Step-for-step coverage:

| Ashod | This PR |
|---|---|
| Catalog pass | \`pu_regress.collect_catalog\` |
| Embedding extraction per (model, size, modality) | \`pu_regress.extract_embeddings\` (cached) |
| Linear probe → R² | \`pu_regress._probe_with_pvalue\` (+ p-value, new) |
| kNN graph per embedding | \`pu_regress._build_knn\` (faiss/sklearn) |
| MKNN overlap intramodal + crossmodal | \`pu_regress_pairs.mknn_overlap\` |
| Wasserstein per property | \`pu_regress_pairs.wasserstein_per_property\` |
| Plots | (out of scope — UMAP coords saved so plotting is one short script) |

## Anonymisation / generality

Same pattern as the rest of \`experiments/platonic/\`. All knobs via env vars; no hard-coded HF tokens, namespaces, paths, or accounts. Scripts fail loudly if any required env is unset.

## Tested

End-to-end on a local RTX 5070 with N=300 / k=10 / B=20:

\`\`\`
[claim] hsc__dinov3_vits16 (facebook/dinov3-vits16-pretrain-lvd1689m, params_M=22)
catalog: 300 rows, 6 fields
extracted (300, 384), cached
building cosine kNN graph (k=10)
computing UMAP-2D (precomputed kNN)
  R²(redshift) = -1.71 ± 0.85  p=0.0476
  R²(mag_g)    = 0.39  ± 0.09  p=0.0476
  R²(mag_r)    = 0.44  ± 0.14  p=0.0476
  R²(mass)     = -1.74 ± 0.27  p=0.0476
  R²(sSFR)     = -1.39 ± 0.54  p=0.0476
  R²(g-r)      = 0.14  ± 0.08  p=0.0476
[done] hsc__dinov3_vits16 -> done/hsc__dinov3_vits16/{probe,neighbours,umap}.parquet
\`\`\`

UMAP parquet: \`(300, 3)\` with finite \`(umap_x, umap_y)\`.
Pairs aggregator on two tuples produces 1 intramodal pair: \`MKNN=0.36\`, all 6 Wasserstein distances populated.