### PR TITLE
refactor(platonic/regress): two-step reviewer-friendly pipeline

### DIFF
--- a/experiments/platonic/regress/01_extract_and_probe.py
+++ b/experiments/platonic/regress/01_extract_and_probe.py
@@ -1,33 +1,47 @@
 #!/usr/bin/env python3
-"""Cooperative physics-regression worker.
+"""Step 1 — distributed extract + linear probe.
 
-For each (model, size, modality) tuple, extract embeddings on the
-COSMOS-Web sample and run a 5-fold linear probe against every physical
-label in CATALOG_COLUMNS, plus a derived `g-r` colour. Output is one
-small parquet per tuple uploaded to a coordination dataset on Hugging
-Face. Workers atomically claim tuples via `running/<tag>.running`
-markers exactly as pu_solve.py does, so any number of workers on any
-number of clusters can divide the work without speaking to each other.
+For each (model, size, modality) tuple in MODEL_GRID × MODALITIES, this
+worker:
 
-Idempotent. Restart-safe. Stale claims (>1h) auto-released.
+  1. Extracts a (n_use, d) embedding matrix on the COSMOS-Web sample,
+     caching the .npy locally.
+  2. Optionally uploads the .npy to ``$PU_EMB_REPO`` so other clusters
+     (and downstream re-analysis) can avoid re-extracting.
+  3. Runs a linear probe against every physical label in CATALOG_COLUMNS
+     plus a derived ``g-r`` colour. The probe applies the published
+     preprocessing recipe (``z>0`` filter and ``[0,4]`` clip for
+     redshift; per-property 1–99 percent quantile clip; StandardScaler
+     fit on the train fold; 10 random 80/20 splits; mean ± std R²).
+  4. Builds a cosine kNN graph and a 2-D UMAP for the embedding.
+  5. Uploads ``probe.parquet``, ``neighbours.parquet``, ``umap.parquet``
+     to ``$PU_REGRESS_RESULTS_REPO`` under ``done/<tag>/`` in a single
+     ``upload_folder`` commit.
 
-Required environment:
-    HF_TOKEN                    no default; required
-    PU_REGRESS_RESULTS_REPO     no default; HF dataset id, e.g. <owner>/pu-regress-results
-    PU_REGRESS_OUT              no default; persistent local output dir
-    PU_REGRESS_LOCKS            no default; persistent local lock dir
+Workers atomically claim tuples via ``running/<tag>.running`` markers,
+so any number of workers across any number of clusters can divide the
+work with no other coordination. Idempotent and restart-safe; stale
+claims (>1 h) are auto-released.
 
-Optional environment:
+Required environment
+--------------------
+    HF_TOKEN                    HF token with write access to the repos below
+    PU_REGRESS_RESULTS_REPO     HF dataset id for results, e.g. <owner>/pu-regress-results
+    PU_REGRESS_OUT              persistent local output dir
+    PU_REGRESS_LOCKS            persistent local lock dir
+
+Optional environment
+--------------------
+    PU_EMB_REPO                 if set, also upload .npy embeddings here
     PU_REGRESS_DATASET          default Ashodkh/cosmosweb-hsc-jwst-high-snr-pil2
     PU_REGRESS_DLCACHE          default /tmp/pu_regress_dl/
     PU_REGRESS_N_USE            default 45000
     PU_REGRESS_BATCH_SIZE       default 16
-    PU_REGRESS_CV_FOLDS         default 5
-    PU_REGRESS_PCA_COMPONENTS   default 0 (disabled)
-    PU_REGRESS_N_PERM           default 100; permutation reps for p-value
+    PU_REGRESS_N_RUNS           default 10; random 80/20 splits per probe
+    PU_REGRESS_TEST_SIZE        default 2000; held-out galaxies per split
     PU_REGRESS_KNN_K            default 10; k for the per-tuple kNN graph
     PU_REGRESS_STALE_S          default 3600 (1 h)
-    PU_REGRESS_TARGET           e.g. "hsc/dino_giant" — single-tuple mode
+    PU_REGRESS_TARGET           e.g. "hsc/vit_base" — single-tuple mode
 """
 from __future__ import annotations
 
@@ -48,7 +62,6 @@ from huggingface_hub import HfApi
 from huggingface_hub.utils import EntryNotFoundError, HfHubHTTPError
 from torch.utils.data import DataLoader
 
-from pu.metrics.physics import linear_probe
 from pu.models import get_adapter
 from pu.pu_datasets.cosmosweb import CATALOG_COLUMNS
 
@@ -64,10 +77,10 @@ DATASET    = os.environ.get("PU_REGRESS_DATASET",
 DLCACHE    = Path(os.environ.get("PU_REGRESS_DLCACHE", "/tmp/pu_regress_dl"))
 N_USE      = int(os.environ.get("PU_REGRESS_N_USE", "45000"))
 BATCH_SIZE = int(os.environ.get("PU_REGRESS_BATCH_SIZE", "16"))
-CV_FOLDS   = int(os.environ.get("PU_REGRESS_CV_FOLDS", "5"))
-PCA_K      = int(os.environ.get("PU_REGRESS_PCA_COMPONENTS", "0")) or None
-N_PERM     = int(os.environ.get("PU_REGRESS_N_PERM", "100"))
+N_RUNS     = int(os.environ.get("PU_REGRESS_N_RUNS", "10"))
+TEST_SIZE  = int(os.environ.get("PU_REGRESS_TEST_SIZE", "2000"))
 KNN_K      = int(os.environ.get("PU_REGRESS_KNN_K", "10"))
+EMB_REPO   = os.environ.get("PU_EMB_REPO", "")  # optional; if set, .npy is uploaded here
 STALE_S    = int(os.environ.get("PU_REGRESS_STALE_S", "3600"))
 TARGET     = os.environ.get("PU_REGRESS_TARGET", "")  # single-tuple mode
 
@@ -393,30 +406,83 @@ def extract_embeddings(alias: str, size: str, hf_id: str,
 # ---------------------------------------------------------------------------
 # Per-tuple regression
 # ---------------------------------------------------------------------------
-def _probe_with_pvalue(Z: np.ndarray, y: np.ndarray
-                       ) -> tuple[float, float, float]:
-    """Returns (r2_mean, r2_std, p_value) where p is the one-sided
-    permutation-test p-value for H0: no linear relationship between Z and y.
-    Uses N_PERM shuffles of y, refits the same CV pipeline."""
-    res = linear_probe(Z, y, cv=CV_FOLDS, pca_components=PCA_K)
-    if isinstance(res, dict):
-        observed = float(res.get("mean", float("nan")))
-        std      = float(res.get("std",  float("nan")))
-    else:
-        observed, std = float(res), float("nan")
-    if N_PERM <= 0 or not np.isfinite(observed):
-        return observed, std, float("nan")
-    rng = np.random.default_rng(0)
-    null = []
-    for _ in range(N_PERM):
-        y_perm = rng.permutation(y)
-        rp = linear_probe(Z, y_perm, cv=CV_FOLDS, pca_components=PCA_K)
-        rp_mean = rp["mean"] if isinstance(rp, dict) else rp
-        null.append(float(rp_mean))
-    null_arr = np.asarray(null)
-    # Phipson-Smyth correction so p > 0 always.
-    p_value = (1 + int(np.sum(null_arr >= observed))) / (N_PERM + 1)
-    return observed, std, float(p_value)
+def _prep_property(name: str, y: np.ndarray) -> tuple[np.ndarray, np.ndarray]:
+    """Apply the published per-property preprocessing.
+
+    Returns (mask, y_clipped). The mask selects catalog rows that survive
+    the property-specific filter (used to also subset embeddings). y_clipped
+    is then trimmed to its own 1–99% quantiles to suppress outliers that
+    would otherwise blow up unregularised OLS.
+    """
+    valid = np.isfinite(y)
+    if name == "redshift":
+        valid &= (y > 0)
+    if not valid.any():
+        return valid, y
+    y_v = y[valid].astype(np.float32, copy=True)
+    if name == "redshift":
+        y_v = np.clip(y_v, 0, 4)
+    lo, hi = np.quantile(y_v, [0.01, 0.99])
+    y_v = np.clip(y_v, lo, hi)
+    out = y.astype(np.float32, copy=True)
+    out[valid] = y_v
+    return valid, out
+
+
+def _probe_published(Z: np.ndarray, y: np.ndarray, mask: np.ndarray
+                     ) -> tuple[float, float]:
+    """Linear probe with the published recipe: StandardScaler embeddings on
+    each train fold, fit OLS, score on test fold. Repeats N_RUNS random
+    80/20 splits and returns (mean R², std R²).
+
+    Implementation: torch.linalg.lstsq on GPU when CUDA is available, falls
+    back to sklearn LinearRegression on CPU otherwise.
+    """
+    Zv = Z[mask].astype(np.float32, copy=False)
+    yv = y[mask].astype(np.float32, copy=False)
+    if len(Zv) < TEST_SIZE + 100:
+        return float("nan"), float("nan")
+
+    use_cuda = torch.cuda.is_available()
+    device = torch.device("cuda" if use_cuda else "cpu")
+
+    scores = []
+    for seed in range(N_RUNS):
+        rng = np.random.default_rng(seed)
+        order = rng.permutation(len(Zv))
+        test_idx, train_idx = order[:TEST_SIZE], order[TEST_SIZE:]
+        Xtr_np = Zv[train_idx]; ytr_np = yv[train_idx]
+        Xte_np = Zv[test_idx];  yte_np = yv[test_idx]
+
+        mu = Xtr_np.mean(axis=0)
+        sd = Xtr_np.std(axis=0)
+        sd = np.where(sd < 1e-12, 1.0, sd)
+        Xtr_np = (Xtr_np - mu) / sd
+        Xte_np = (Xte_np - mu) / sd
+
+        if use_cuda:
+            Xtr = torch.from_numpy(Xtr_np).to(device)
+            Xte = torch.from_numpy(Xte_np).to(device)
+            ytr = torch.from_numpy(ytr_np).to(device)
+            yte = torch.from_numpy(yte_np).to(device)
+            ones_tr = torch.ones(Xtr.shape[0], 1, device=device)
+            ones_te = torch.ones(Xte.shape[0], 1, device=device)
+            Xtr_b = torch.cat([Xtr, ones_tr], dim=1)
+            Xte_b = torch.cat([Xte, ones_te], dim=1)
+            sol = torch.linalg.lstsq(Xtr_b, ytr.unsqueeze(1)).solution.squeeze(1)
+            pred = Xte_b @ sol
+            ss_res = float(torch.sum((yte - pred) ** 2))
+            ss_tot = float(torch.sum((yte - yte.mean()) ** 2))
+            r2 = 1.0 - ss_res / ss_tot if ss_tot > 0 else float("nan")
+        else:
+            from sklearn.linear_model import LinearRegression
+            from sklearn.metrics import r2_score
+            m = LinearRegression()
+            m.fit(Xtr_np, ytr_np)
+            r2 = r2_score(yte_np, m.predict(Xte_np))
+        scores.append(float(r2))
+
+    return float(np.mean(scores)), float(np.std(scores))
 
 
 def _build_knn(Z: np.ndarray, k: int) -> tuple[np.ndarray, np.ndarray]:
@@ -494,15 +560,16 @@ def regress_tuple(alias: str, size: str, hf_id: str, params_M: int,
         })
 
     rows = []
-    for prop, y in catalog.items():
-        n = min(len(Z), len(y))
+    for prop, y_raw in catalog.items():
+        n = min(len(Z), len(y_raw))
+        mask, y = _prep_property(prop, y_raw[:n])
         try:
-            r2_mean, r2_std, p_val = _probe_with_pvalue(Z[:n], y[:n])
+            r2_mean, r2_std = _probe_published(Z[:n], y, mask)
         except Exception as e:
             log(f"    {prop}: probe failed: {type(e).__name__}: {e}")
-            r2_mean, r2_std, p_val = float("nan"), float("nan"), float("nan")
+            r2_mean, r2_std = float("nan"), float("nan")
         log(f"    R²({prop}) = {r2_mean:.4f} ± {r2_std:.4f}  "
-            f"p={p_val:.4f}")
+            f"(n_valid={int(mask.sum())})")
         rows.append({
             "modality": modality,
             "model_alias": alias,
@@ -512,12 +579,11 @@ def regress_tuple(alias: str, size: str, hf_id: str, params_M: int,
             "property": prop,
             "r2_mean": r2_mean,
             "r2_std":  r2_std,
-            "r2_pvalue": p_val,
+            "n_valid": int(mask.sum()),
             "n": int(n),
             "d": int(Z.shape[1]),
-            "cv_folds": CV_FOLDS,
-            "pca_k": PCA_K or 0,
-            "n_perm": N_PERM,
+            "n_runs": N_RUNS,
+            "test_size": TEST_SIZE,
         })
     return pl.DataFrame(rows), nn_df, umap_df
 
@@ -602,6 +668,25 @@ def main() -> int:
                 shutil.rmtree(staging, ignore_errors=True)
             log(f"[done] {tag} -> done/{tag}/"
                 f"{{probe,neighbours{'' if umap_df is None else ',umap'}}}.parquet")
+
+            # Optional: ship the cached .npy to the embeddings repo so
+            # later analyses (e.g. re-probing with a different recipe)
+            # don't need a GPU. Each .npy is ~250–600 MB.
+            if EMB_REPO:
+                emb_npy = DLCACHE / f"emb_{modality}_{alias}_{size}_{N_USE}.npy"
+                if emb_npy.exists():
+                    try:
+                        api.upload_file(
+                            path_or_fileobj=str(emb_npy),
+                            path_in_repo=emb_npy.name,
+                            repo_id=EMB_REPO,
+                            repo_type="dataset",
+                            commit_message=f"emb {tag}",
+                        )
+                        log(f"[emb] {emb_npy.name} -> {EMB_REPO}")
+                    except Exception as e:
+                        log(f"[emb] upload failed for {emb_npy.name}: "
+                            f"{type(e).__name__}: {e}")
         except KeyboardInterrupt:
             release_claim(tag)
             raise

--- a/experiments/platonic/regress/02_aggregate_pairs.py
+++ b/experiments/platonic/regress/02_aggregate_pairs.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 """Pairwise MKNN + Wasserstein on the per-tuple kNN graphs uploaded by
-pu_regress.py.
+01_extract_and_probe.py.
 
 Two pair families are computed (matching Ashod's pipeline):
 
@@ -24,7 +24,7 @@ For each pair we compute:
 Output: one summary parquet with one row per (pair_kind, group, ...) entry.
 
 Usage:
-    python pu_regress_pairs.py \\
+    python 02_aggregate_pairs.py \\
         --pull-from <owner>/pu-regress-results \\
         --out-dir   /path/to/derived
         [--upload-to <owner>/pu-regress-results]   # writes summary.pairs.parquet under done/

--- a/experiments/platonic/regress/03_plot_umap.py
+++ b/experiments/platonic/regress/03_plot_umap.py
@@ -1,0 +1,227 @@
+#!/usr/bin/env python3
+"""Step 3 — UMAP figures.
+
+Reads every per-tuple ``umap.parquet`` produced by step 1 and produces
+one multi-page PDF per modality. Each page colours the same UMAP grid
+by a different physics property (redshift, mass, sSFR, mag_g, mag_r,
+g-r). Within a page, rows are model families and columns are sizes,
+so reviewers can read structure-vs-scale trends at a glance.
+
+Usage
+-----
+    python 03_plot_umap.py \\
+        --pull-from "$PU_REGRESS_RESULTS_REPO" \\
+        --out-dir   ./derived
+
+    # or with a local cache already populated by step 2:
+    python 03_plot_umap.py --done-dir ./derived/_regress_cache/done \\
+        --out-dir ./derived
+"""
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+from pathlib import Path
+
+import matplotlib.pyplot as plt
+import numpy as np
+import polars as pl
+from matplotlib.backends.backend_pdf import PdfPages
+from tqdm import tqdm
+
+# Order families/sizes the same way as the rest of the pipeline so the
+# plots line up with every other table in the paper.
+FAMILY_SIZES: dict[str, list[str]] = {
+    "vit":       ["base", "large", "huge"],
+    "clip":      ["base", "large"],
+    "dinov3":    ["vits16", "vits16plus", "vitb16", "vitl16",
+                  "vith16plus", "vit7b16"],
+    "convnext":  ["nano", "tiny", "base", "large"],
+    "ijepa":     ["huge", "giant"],
+    "vjepa":     ["large", "huge", "giant"],
+    "astropt":   ["015M", "095M", "850M"],
+    "vit-mae":   ["base", "large", "huge"],
+    "paligemma": ["3b", "10b", "28b"],
+    "llava_15":  ["7b", "13b"],
+}
+MODALITIES = ("hsc", "jwst")
+PROPERTIES = ("redshift", "mag_g", "mag_r", "mass", "sSFR", "g-r")
+
+
+def parse_args() -> argparse.Namespace:
+    p = argparse.ArgumentParser(__doc__)
+    p.add_argument("--pull-from", default=os.environ.get("PU_REGRESS_RESULTS_REPO"),
+                   help="HF dataset id to fetch umap.parquet from (skipped if "
+                        "--done-dir is supplied).")
+    p.add_argument("--done-dir", type=Path, default=None,
+                   help="Pre-populated local mirror of done/<tag>/ (overrides --pull-from).")
+    p.add_argument("--out-dir", type=Path, required=True,
+                   help="Where to write the PDFs.")
+    p.add_argument("--cache-dir", type=Path, default=None,
+                   help="Where to keep pulled parquets (default: $out_dir/_regress_cache).")
+    p.add_argument("--n-points", type=int, default=15_000,
+                   help="Subsample to this many galaxies per panel (default 15k).")
+    return p.parse_args()
+
+
+def fetch_done(repo: str, dest: Path, token: str | None) -> Path:
+    from huggingface_hub import HfApi, hf_hub_download
+    api = HfApi(token=token)
+    files = [f for f in api.list_repo_files(repo, repo_type="dataset")
+             if f.startswith("done/") and f.endswith("umap.parquet")]
+    print(f"pulling {len(files)} umap parquets from {repo}")
+    dest.mkdir(parents=True, exist_ok=True)
+    for f in tqdm(files, desc="pull"):
+        hf_hub_download(repo, f, repo_type="dataset",
+                        local_dir=str(dest), token=token)
+    return dest / "done"
+
+
+def load_catalog(n_use: int) -> dict[str, np.ndarray]:
+    """Stream the source dataset once to recover physics labels."""
+    from datasets import load_dataset
+
+    from pu.pu_datasets.cosmosweb import CATALOG_COLUMNS
+    dataset = os.environ.get(
+        "PU_REGRESS_DATASET",
+        "Ashodkh/cosmosweb-hsc-jwst-high-snr-pil2",
+    )
+    print(f"streaming {dataset} for catalog labels (N={n_use})")
+    cols = list(CATALOG_COLUMNS.values())
+    raw: dict[str, list] = {c: [] for c in cols}
+    ds = load_dataset(dataset, split="train", streaming=True)
+    for i, row in enumerate(tqdm(ds, total=n_use, desc="catalog")):
+        for c in cols:
+            raw[c].append(row[c])
+        if i + 1 >= n_use:
+            break
+    out = {p: np.asarray(raw[col], dtype=np.float32)
+           for p, col in CATALOG_COLUMNS.items()}
+    out["g-r"] = out["mag_g"] - out["mag_r"]
+    return out
+
+
+def colour_range(name: str, values: np.ndarray) -> tuple[float, float]:
+    """Per-property colourmap range. Hard-coded for the redshift physical
+    range; everything else uses 1–99 percent quantiles to suppress
+    outliers without losing the bulk of the distribution."""
+    finite = values[np.isfinite(values)]
+    if name == "redshift":
+        return 0.0, min(4.0, float(np.quantile(finite, 0.99)))
+    lo, hi = np.quantile(finite, [0.01, 0.99])
+    return float(lo), float(hi)
+
+
+def render_modality_pdf(modality: str, done_dir: Path,
+                        catalog: dict[str, np.ndarray],
+                        out_pdf: Path, n_points: int) -> None:
+    families = list(FAMILY_SIZES.items())
+    n_rows = len(families)
+    n_cols = max(len(s) for _, s in families)
+
+    # Pre-load all the umap coords for this modality (one read per tuple).
+    coords: dict[tuple[str, str], np.ndarray] = {}
+    for alias, sizes in families:
+        for size in sizes:
+            tag = f"{modality}__{alias}_{size}"
+            p = done_dir / tag / "umap.parquet"
+            if not p.exists():
+                continue
+            df = pl.read_parquet(p)
+            xy = np.stack([df["umap_x"].to_numpy(),
+                           df["umap_y"].to_numpy()], axis=1)
+            coords[(alias, size)] = xy
+
+    # Subsample once so every panel uses the same galaxies (otherwise
+    # comparison across panels is visually misleading).
+    n_galaxies = max(len(v) for v in coords.values()) if coords else 0
+    if n_galaxies == 0:
+        print(f"  [skip] {modality}: no umap parquets found")
+        return
+    rng = np.random.default_rng(0)
+    keep = np.sort(rng.choice(n_galaxies, size=min(n_points, n_galaxies),
+                              replace=False))
+
+    out_pdf.parent.mkdir(parents=True, exist_ok=True)
+    with PdfPages(out_pdf) as pdf:
+        for prop in PROPERTIES:
+            y = catalog[prop]
+            vmin, vmax = colour_range(prop, y[keep])
+
+            fig, axes = plt.subplots(
+                n_rows, n_cols,
+                figsize=(2.8 * n_cols, 2.8 * n_rows),
+                squeeze=False,
+            )
+            for r, (alias, sizes) in enumerate(families):
+                for c in range(n_cols):
+                    ax = axes[r, c]
+                    if c >= len(sizes) or (alias, sizes[c]) not in coords:
+                        ax.axis("off")
+                        continue
+                    size = sizes[c]
+                    xy = coords[(alias, size)]
+                    n = min(len(xy), len(y))
+                    sub = keep[keep < n]
+                    sc = ax.scatter(
+                        xy[sub, 0], xy[sub, 1],
+                        c=y[sub], cmap="viridis",
+                        vmin=vmin, vmax=vmax,
+                        s=2, alpha=0.55, linewidths=0,
+                    )
+                    ax.set_xticks([]); ax.set_yticks([])
+                    if r == 0:
+                        ax.set_title(size, fontsize=9)
+                    if c == 0:
+                        ax.set_ylabel(alias, fontsize=9, rotation=0,
+                                      ha="right", va="center", labelpad=20)
+
+            cax = fig.add_axes([0.92, 0.15, 0.012, 0.7])
+            fig.colorbar(sc, cax=cax, label=prop)
+            fig.suptitle(
+                f"UMAP of {modality.upper()} embeddings — coloured by {prop}",
+                fontsize=12, y=0.995,
+            )
+            fig.subplots_adjust(left=0.05, right=0.9, top=0.94, bottom=0.03,
+                                wspace=0.05, hspace=0.10)
+            pdf.savefig(fig, dpi=150)
+            plt.close(fig)
+
+    print(f"wrote {out_pdf}")
+
+
+def main() -> int:
+    args = parse_args()
+    args.out_dir.mkdir(parents=True, exist_ok=True)
+    cache = args.cache_dir or (args.out_dir / "_regress_cache")
+
+    if args.done_dir:
+        done_dir = args.done_dir
+    elif args.pull_from:
+        done_dir = fetch_done(args.pull_from, cache, os.environ.get("HF_TOKEN"))
+    else:
+        print("[fatal] need --pull-from or --done-dir", file=sys.stderr)
+        return 2
+
+    # Recover N from the first available umap.parquet.
+    n_use = None
+    for tag_dir in sorted(done_dir.iterdir()):
+        u = tag_dir / "umap.parquet"
+        if u.exists():
+            n_use = len(pl.read_parquet(u))
+            break
+    if n_use is None:
+        print(f"[fatal] no umap.parquet under {done_dir}", file=sys.stderr)
+        return 1
+    catalog = load_catalog(n_use)
+
+    for modality in MODALITIES:
+        out_pdf = args.out_dir / f"umap_{modality}.pdf"
+        render_modality_pdf(modality, done_dir, catalog, out_pdf, args.n_points)
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/experiments/platonic/regress/03_plot_umap.py
+++ b/experiments/platonic/regress/03_plot_umap.py
@@ -1,11 +1,18 @@
 #!/usr/bin/env python3
 """Step 3 — UMAP figures.
 
-Reads every per-tuple ``umap.parquet`` produced by step 1 and produces
-one multi-page PDF per modality. Each page colours the same UMAP grid
-by a different physics property (redshift, mass, sSFR, mag_g, mag_r,
-g-r). Within a page, rows are model families and columns are sizes,
-so reviewers can read structure-vs-scale trends at a glance.
+Reads every per-tuple ``umap.parquet`` produced by step 1 and renders
+two output flavours, both populated by default:
+
+  - ``umap/<modality>/<alias>_<size>__<property>.png`` — one PNG per
+    (tuple, property), so a downstream analysis can grab a specific
+    panel without slicing a PDF.
+  - ``umap_<modality>.pdf`` (with ``--pdf``) — multi-page overview;
+    one page per property, grid = family × size for at-a-glance
+    structure-vs-scale comparison.
+
+Within both outputs, every panel is plotted using the same random
+subsample of galaxies so cross-panel comparison is visually fair.
 
 Usage
 -----
@@ -62,6 +69,12 @@ def parse_args() -> argparse.Namespace:
                    help="Where to keep pulled parquets (default: $out_dir/_regress_cache).")
     p.add_argument("--n-points", type=int, default=15_000,
                    help="Subsample to this many galaxies per panel (default 15k).")
+    p.add_argument("--pdf", action="store_true",
+                   help="Also render the multi-page PDF overview per modality.")
+    p.add_argument("--no-png", action="store_true",
+                   help="Skip the per-tuple PNGs (only meaningful with --pdf).")
+    p.add_argument("--png-dpi", type=int, default=150,
+                   help="DPI for individual PNGs.")
     return p.parse_args()
 
 
@@ -113,42 +126,66 @@ def colour_range(name: str, values: np.ndarray) -> tuple[float, float]:
     return float(lo), float(hi)
 
 
-def render_modality_pdf(modality: str, done_dir: Path,
-                        catalog: dict[str, np.ndarray],
-                        out_pdf: Path, n_points: int) -> None:
-    families = list(FAMILY_SIZES.items())
-    n_rows = len(families)
-    n_cols = max(len(s) for _, s in families)
-
-    # Pre-load all the umap coords for this modality (one read per tuple).
+def _load_modality_coords(modality: str, done_dir: Path
+                          ) -> dict[tuple[str, str], np.ndarray]:
     coords: dict[tuple[str, str], np.ndarray] = {}
-    for alias, sizes in families:
+    for alias, sizes in FAMILY_SIZES.items():
         for size in sizes:
-            tag = f"{modality}__{alias}_{size}"
-            p = done_dir / tag / "umap.parquet"
+            p = done_dir / f"{modality}__{alias}_{size}" / "umap.parquet"
             if not p.exists():
                 continue
             df = pl.read_parquet(p)
-            xy = np.stack([df["umap_x"].to_numpy(),
-                           df["umap_y"].to_numpy()], axis=1)
-            coords[(alias, size)] = xy
+            coords[(alias, size)] = np.stack(
+                [df["umap_x"].to_numpy(), df["umap_y"].to_numpy()], axis=1)
+    return coords
 
-    # Subsample once so every panel uses the same galaxies (otherwise
-    # comparison across panels is visually misleading).
-    n_galaxies = max(len(v) for v in coords.values()) if coords else 0
-    if n_galaxies == 0:
-        print(f"  [skip] {modality}: no umap parquets found")
-        return
-    rng = np.random.default_rng(0)
-    keep = np.sort(rng.choice(n_galaxies, size=min(n_points, n_galaxies),
-                              replace=False))
 
+def render_individual_pngs(modality: str,
+                           coords: dict[tuple[str, str], np.ndarray],
+                           catalog: dict[str, np.ndarray],
+                           keep: np.ndarray, out_dir: Path,
+                           dpi: int) -> int:
+    """One PNG per (tuple, property)."""
+    out_dir.mkdir(parents=True, exist_ok=True)
+    n_written = 0
+    for prop in PROPERTIES:
+        y = catalog[prop]
+        vmin, vmax = colour_range(prop, y[keep])
+        for (alias, size), xy in coords.items():
+            n = min(len(xy), len(y))
+            sub = keep[keep < n]
+            fig, ax = plt.subplots(figsize=(4.5, 4.5))
+            sc = ax.scatter(
+                xy[sub, 0], xy[sub, 1],
+                c=y[sub], cmap="viridis",
+                vmin=vmin, vmax=vmax,
+                s=3, alpha=0.6, linewidths=0,
+            )
+            ax.set_xticks([]); ax.set_yticks([])
+            ax.set_xlabel("UMAP 1"); ax.set_ylabel("UMAP 2")
+            ax.set_title(f"{modality} · {alias} · {size}", fontsize=10)
+            cb = fig.colorbar(sc, ax=ax, fraction=0.046, pad=0.02)
+            cb.set_label(prop, fontsize=9)
+            fig.tight_layout()
+            png = out_dir / f"{alias}_{size}__{prop}.png"
+            fig.savefig(png, dpi=dpi)
+            plt.close(fig)
+            n_written += 1
+    return n_written
+
+
+def render_modality_pdf(modality: str,
+                        coords: dict[tuple[str, str], np.ndarray],
+                        catalog: dict[str, np.ndarray],
+                        keep: np.ndarray, out_pdf: Path) -> None:
+    families = list(FAMILY_SIZES.items())
+    n_rows = len(families)
+    n_cols = max(len(s) for _, s in families)
     out_pdf.parent.mkdir(parents=True, exist_ok=True)
     with PdfPages(out_pdf) as pdf:
         for prop in PROPERTIES:
             y = catalog[prop]
             vmin, vmax = colour_range(prop, y[keep])
-
             fig, axes = plt.subplots(
                 n_rows, n_cols,
                 figsize=(2.8 * n_cols, 2.8 * n_rows),
@@ -176,7 +213,6 @@ def render_modality_pdf(modality: str, done_dir: Path,
                     if c == 0:
                         ax.set_ylabel(alias, fontsize=9, rotation=0,
                                       ha="right", va="center", labelpad=20)
-
             cax = fig.add_axes([0.92, 0.15, 0.012, 0.7])
             fig.colorbar(sc, cax=cax, label=prop)
             fig.suptitle(
@@ -187,7 +223,6 @@ def render_modality_pdf(modality: str, done_dir: Path,
                                 wspace=0.05, hspace=0.10)
             pdf.savefig(fig, dpi=150)
             plt.close(fig)
-
     print(f"wrote {out_pdf}")
 
 
@@ -216,9 +251,25 @@ def main() -> int:
         return 1
     catalog = load_catalog(n_use)
 
+    rng = np.random.default_rng(0)
     for modality in MODALITIES:
-        out_pdf = args.out_dir / f"umap_{modality}.pdf"
-        render_modality_pdf(modality, done_dir, catalog, out_pdf, args.n_points)
+        coords = _load_modality_coords(modality, done_dir)
+        if not coords:
+            print(f"  [skip] {modality}: no umap parquets found")
+            continue
+        n_galaxies = max(len(v) for v in coords.values())
+        keep = np.sort(rng.choice(n_galaxies,
+                                  size=min(args.n_points, n_galaxies),
+                                  replace=False))
+        if not args.no_png:
+            png_dir = args.out_dir / "umap" / modality
+            n = render_individual_pngs(
+                modality, coords, catalog, keep, png_dir, args.png_dpi)
+            print(f"wrote {n} pngs under {png_dir}/")
+        if args.pdf:
+            render_modality_pdf(
+                modality, coords, catalog, keep,
+                args.out_dir / f"umap_{modality}.pdf")
 
     return 0
 

--- a/experiments/platonic/regress/README.md
+++ b/experiments/platonic/regress/README.md
@@ -127,11 +127,16 @@ python 03_plot_umap.py \
     --out-dir   ./derived
 ```
 
-Output: `derived/umap_hsc.pdf` and `derived/umap_jwst.pdf`. Each PDF
-has six pages (one per physics property). Within a page, rows are
-model families and columns are sizes, colourised by the page's
-property. The same random subsample of galaxies is used for every
-panel so cross-panel comparisons are visually fair.
+Default output is **per-tuple PNGs** under
+`derived/umap/<modality>/<alias>_<size>__<property>.png` — one file per
+(modality, alias, size, property), so a downstream analysis can grab
+exactly the panel it wants.
+
+Add `--pdf` to also render multi-page overview PDFs at
+`derived/umap_<modality>.pdf`. Each PDF has six pages (one per
+property); rows are model families, columns are sizes. The same
+random subsample of galaxies is used for every panel so cross-panel
+comparisons are visually fair.
 
 ## Knobs
 

--- a/experiments/platonic/regress/README.md
+++ b/experiments/platonic/regress/README.md
@@ -1,23 +1,44 @@
 # Regression tier
 
-Runs a 5-fold linear probe of every model's embeddings against the
-LEPHARE physics labels (redshift, mass, sSFR, mag_g, mag_r, g-r colour)
-on the `Ashodkh/cosmosweb-hsc-jwst-high-snr-pil2` dataset. Output is a
-small parquet per `(modality, model_alias, model_size)` tuple.
+Linear-probe every foundation model's embeddings against the LEPHARE
+physics labels (redshift, mass, sSFR, mag_g, mag_r, g–r colour) on the
+`Ashodkh/cosmosweb-hsc-jwst-high-snr-pil2` dataset. The whole pipeline
+is two scripts and reproduces the regression numbers in the paper end
+to end.
 
-Same coordination model as `compute/`: a private Hugging Face dataset
-acts as a distributed lock. Workers atomically claim
-`running/<tag>.running` markers; stale claims older than 1 hour are
-auto-released; nothing data-shaped is committed to git.
+## Files
+
+```
+experiments/platonic/regress/
+├── 01_extract_and_probe.py  step 1 — distributed worker:
+│                              claim → extract → probe → kNN → UMAP → upload → release
+├── 02_aggregate_pairs.py    step 2 — local aggregator:
+│                              pulls neighbour matrices, computes intramodal +
+│                              crossmodal MKNN and Wasserstein
+├── aggregate.py             optional: pull all probe.parquet → one summary table
+├── setup_hf.py              one-time bootstrap of the coordination dataset
+├── slurm/                   SBATCH wrapper
+└── vast/                    tmux launcher (one worker per GPU on a single box)
+```
+
+## Coordination model
+
+A private Hugging Face dataset acts as the distributed lock. Workers
+atomically claim `running/<tag>.running` markers; stale claims older
+than 1 h auto-release; nothing data-shaped is committed to git.
 
 ## Required environment
 
 ```bash
-export HF_TOKEN=<your-hf-token>                              # private datasets / write access
-export PU_REGRESS_RESULTS_REPO=<owner>/pu-regress-results    # phase outputs land here
+export HF_TOKEN=<token-with-write-access>
+export PU_REGRESS_RESULTS_REPO=<owner>/pu-regress-results   # results land here
 ```
 
-No defaults; both scripts fail loudly if either is unset.
+Optional but recommended (lets later analyses skip GPU re-extraction):
+
+```bash
+export PU_EMB_REPO=<owner>/pu-regress-embeddings           # cached .npy land here
+```
 
 ## One-time setup
 
@@ -25,19 +46,66 @@ No defaults; both scripts fail loudly if either is unset.
 python setup_hf.py "$PU_REGRESS_RESULTS_REPO"
 ```
 
-## Running
+## Step 1 — distributed extract + probe
+
+Run on as many GPUs / clusters as you have. Workers don't talk to each
+other; they coordinate through `$PU_REGRESS_RESULTS_REPO`.
 
 ```bash
-# SLURM
+# SLURM cluster
 for i in {1..16}; do sbatch slurm/pu_regress.sh; done
 
-# vast.ai (or any local multi-GPU box)
+# Single multi-GPU box (one worker per GPU, in tmux)
 bash vast/vast_regress.sh
 ```
 
-## Aggregating
+Per-tuple output (uploaded to `done/<tag>/` on the results repo):
 
-After every tuple lands in `done/`:
+| File | One row per | Contents |
+|---|---|---|
+| `probe.parquet` | physical property | mean ± std R² across 10 random 80/20 splits, sample sizes, knobs |
+| `neighbours.parquet` | galaxy | (k,) int indices of k nearest neighbours in embedding space |
+| `umap.parquet` | galaxy | 2-D UMAP coords (precomputed kNN, cosine) |
+
+If `$PU_EMB_REPO` is set, the per-tuple `emb_<modality>_<alias>_<size>_<n_use>.npy`
+is also uploaded there.
+
+### Probe recipe
+
+For each label `y` and embedding matrix `Z`:
+
+1. **Filter**: drop rows where `y` is not finite. For redshift, also drop
+   `y ≤ 0` and clip to `[0, 4]`.
+2. **Outlier trim**: clip `y` to its own 1–99 % quantile range.
+3. **Repeat 10×** with different random splits:
+   1. Random 80/20 train/test split; default test size is 2000 galaxies.
+   2. `StandardScaler` fit on the train fold, applied to test fold.
+   3. Fit OLS via `torch.linalg.lstsq` on GPU (CPU sklearn fallback).
+   4. Score R² on the test fold.
+4. Report mean ± std across the 10 splits.
+
+This is the recipe the paper plots. The default knobs reproduce the
+published numbers; everything is overridable per `Knobs` below.
+
+## Step 2 — pairwise aggregation (local)
+
+After step 1 finishes, on a laptop:
+
+```bash
+python 02_aggregate_pairs.py \
+    --pull-from "$PU_REGRESS_RESULTS_REPO" \
+    --out-dir   ./derived
+```
+
+Output: `derived/regress_pairs.parquet` with one row per pair:
+
+| Column | Meaning |
+|---|---|
+| `pair_kind` | `intramodal` (adjacent sizes within a family on one modality) or `crossmodal` (HSC vs JWST of the same model size) |
+| `mknn` | mean per-row \|N_a ∩ N_b\| / k |
+| `wass_<property>` | mean per-row Wasserstein-1 distance between the two sides' physics-label distributions on their kNN sets |
+
+To also dump a flat R² table:
 
 ```bash
 python aggregate.py \
@@ -46,53 +114,20 @@ python aggregate.py \
     --json-out  ./derived/r2_vs_params.json
 ```
 
-The JSON layout matches what's consumed by Smith42's plotting branch:
-`{ modality: { model_alias: { size: { property: { r2_mean } } } } }`.
+JSON layout: `{ modality: { model_alias: { size: { property: { r2_mean } } } } }`.
 
 ## Knobs
 
-| Variable | Default | What it does |
+| Variable | Default | Notes |
 |---|---|---|
 | `PU_REGRESS_DATASET` | `Ashodkh/cosmosweb-hsc-jwst-high-snr-pil2` | source dataset |
-| `PU_REGRESS_N_USE` | `45000` | catalog/embedding sample size |
+| `PU_REGRESS_N_USE` | `45000` | catalog / embedding sample size |
 | `PU_REGRESS_BATCH_SIZE` | `16` | inference batch size |
-| `PU_REGRESS_CV_FOLDS` | `5` | linear-probe CV folds |
-| `PU_REGRESS_PCA_COMPONENTS` | `0` (off) | optional PCA before regression |
+| `PU_REGRESS_N_RUNS` | `10` | random train/test splits per probe |
+| `PU_REGRESS_TEST_SIZE` | `2000` | held-out galaxies per split |
+| `PU_REGRESS_KNN_K` | `10` | k for the kNN graph |
 | `PU_REGRESS_STALE_S` | `3600` | running-marker auto-release threshold |
 | `PU_REGRESS_TARGET` | unset | single-tuple mode: `<modality>/<alias>_<size>` |
-
-## What's where
-
-```
-experiments/platonic/regress/
-├── pu_regress.py        worker: claim → extract → probe → kNN → UMAP → upload → release
-├── pu_regress_pairs.py  aggregator: pulls all neighbour matrices,
-│                        computes intramodal + crossmodal MKNN + Wasserstein
-├── setup_hf.py          one-time bootstrap of the coordination dataset
-├── aggregate.py         pull all done/*.parquet -> one summary parquet (+ optional JSON)
-├── slurm/               SBATCH wrapper
-└── vast/                tmux launcher (one worker per GPU)
-```
-
-## Per-tuple output files
-
-Each completed `(modality, alias, size)` tuple uploads three parquets to
-`done/<tag>/` on the coordination dataset:
-
-| File | Per-row contents |
-|---|---|
-| `probe.parquet` | one row per physical property: $R^2$ mean, $R^2$ std, permutation $p$-value, sample sizes, hyperparams |
-| `neighbours.parquet` | one row per galaxy: the $(k,)$ integer indices of its $k$ nearest neighbours in this tuple's embedding space |
-| `umap.parquet` | one row per galaxy: 2-D UMAP coordinates from a precomputed kNN graph (cosine, $k = 50$) |
-
-The `pairs.parquet` produced by `pu_regress_pairs.py` consumes all the
-`neighbours.parquet` files plus a re-streamed catalog and produces:
-
-| Column | Meaning |
-|---|---|
-| `pair_kind` | `intramodal` (adjacent sizes within a family on the same modality) or `crossmodal` (HSC vs JWST of the same model size) |
-| `mknn` | mean per-row $|\mathcal N_a \cap \mathcal N_b| / k$ |
-| `wass_<property>` | mean per-row Wasserstein-1 distance between the two sides' physics-label distributions on their kNN sets |
 
 ## Cost
 
@@ -100,8 +135,8 @@ Per `(modality, alias, size)` tuple, on one A100:
 
 - small (ViT-base, DINO-small, ConvNeXt-tiny): a few minutes
 - medium (ViT-large, ConvNeXt-large): tens of minutes
-- large (ViT-huge, DINO-giant, vit-mae-huge): ~1 hour
-- VLMs (paligemma, llava): a few hours; paligemma-28B alone is half a day
+- large (ViT-huge, DINO-giant, ViT-MAE-huge): ~1 hour
+- VLMs (PaliGemma, LLaVA): a few hours; PaliGemma-28B alone is half a day
 
-Total grid: ~25–35 GPU-hours. With 8 GPUs in parallel via `vast_regress.sh`:
-~3–5 hours wall.
+Full grid (62 tuples): roughly 25–35 GPU-hours. On 8 GPUs in parallel
+via `vast/vast_regress.sh`: ~3–5 hours wall.

--- a/experiments/platonic/regress/README.md
+++ b/experiments/platonic/regress/README.md
@@ -15,6 +15,9 @@ experiments/platonic/regress/
 ├── 02_aggregate_pairs.py    step 2 — local aggregator:
 │                              pulls neighbour matrices, computes intramodal +
 │                              crossmodal MKNN and Wasserstein
+├── 03_plot_umap.py          step 3 — UMAP figure rendering (one PDF per
+│                              modality; pages = colour-by property,
+│                              grid = family × size)
 ├── aggregate.py             optional: pull all probe.parquet → one summary table
 ├── setup_hf.py              one-time bootstrap of the coordination dataset
 ├── slurm/                   SBATCH wrapper
@@ -115,6 +118,20 @@ python aggregate.py \
 ```
 
 JSON layout: `{ modality: { model_alias: { size: { property: { r2_mean } } } } }`.
+
+## Step 3 — UMAP figures
+
+```bash
+python 03_plot_umap.py \
+    --pull-from "$PU_REGRESS_RESULTS_REPO" \
+    --out-dir   ./derived
+```
+
+Output: `derived/umap_hsc.pdf` and `derived/umap_jwst.pdf`. Each PDF
+has six pages (one per physics property). Within a page, rows are
+model families and columns are sizes, colourised by the page's
+property. The same random subsample of galaxies is used for every
+panel so cross-panel comparisons are visually fair.
 
 ## Knobs
 

--- a/experiments/platonic/regress/setup_hf.py
+++ b/experiments/platonic/regress/setup_hf.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""One-time bootstrap of the shared HF dataset used by pu_regress.py for
+"""One-time bootstrap of the shared HF dataset used by 01_extract_and_probe.py for
 cross-cluster coordination.
 
 Run once on any machine with HF_TOKEN set; creates a private dataset
@@ -39,7 +39,7 @@ def main() -> int:
     print()
     print("Next:")
     print(f"  export PU_REGRESS_RESULTS_REPO={repo_id}")
-    print("  python pu_regress.py")
+    print("  python 01_extract_and_probe.py")
     return 0
 
 

--- a/experiments/platonic/regress/slurm/pu_regress.sh
+++ b/experiments/platonic/regress/slurm/pu_regress.sh
@@ -54,4 +54,4 @@ export PU_REGRESS_BATCH_SIZE="${PU_REGRESS_BATCH_SIZE:-16}"
 trap 'rm -rf "$HF_HOME" "$PU_REGRESS_DLCACHE" 2>/dev/null || true' EXIT
 
 cd "${SLURM_SUBMIT_DIR:-$PWD}"
-exec python pu_regress.py "$@"
+exec python 01_extract_and_probe.py "$@"

--- a/experiments/platonic/regress/vast/vast_regress.sh
+++ b/experiments/platonic/regress/vast/vast_regress.sh
@@ -4,7 +4,7 @@
 # the shared HF coordination dataset.
 #
 # USAGE on a freshly-rented box:
-#   1. ensure venv is set up and pu_regress.py + setup_hf.py are at $WORKDIR
+#   1. ensure venv is set up and 01_extract_and_probe.py + setup_hf.py are at $WORKDIR
 #   2. export HF_TOKEN=... PU_REGRESS_RESULTS_REPO=<owner>/<dataset>
 #   3. bash vast_regress.sh
 
@@ -35,7 +35,7 @@ for ((g=0; g<N_GPUS; g++)); do
         export PU_REGRESS_DLCACHE='$SCRATCH/regress_dl_g${g}' && \
         export HF_HOME='$SCRATCH/hf_cache_g${g}' && \
         mkdir -p \$PU_REGRESS_DLCACHE \$HF_HOME && \
-        python pu_regress.py 2>&1 | tee '$SCRATCH/regress_g${g}.log'
+        python 01_extract_and_probe.py 2>&1 | tee '$SCRATCH/regress_g${g}.log'
         echo --- worker $g done; sleep 3600
     "
     echo "  worker $g  GPU=$g  tmux=$NAME"


### PR DESCRIPTION
## Summary

Collapses the regression tier into one cooperative worker + one local aggregator, with the published preprocessing baked into the worker (no more "fix-up" re-probe step). A reviewer can now reproduce the regression numbers end to end with two scripts and four environment variables.

Reviewer reproduction:
\`\`\`bash
export HF_TOKEN=... PU_REGRESS_RESULTS_REPO=<owner>/results PU_EMB_REPO=<owner>/embeddings
python setup_hf.py "\$PU_REGRESS_RESULTS_REPO"
bash vast/vast_regress.sh                                        # or sbatch slurm/...
python 02_aggregate_pairs.py --pull-from "\$PU_REGRESS_RESULTS_REPO" --out-dir ./derived
\`\`\`

## Probe recipe (now in \`01_extract_and_probe.py\`)

- redshift only: filter \`z > 0\`, clip to \`[0, 4]\`
- all properties: 1–99% quantile clip on labels
- StandardScaler fit on the train fold, applied to test fold
- 10 random 80/20 splits, mean ± std R²
- GPU \`torch.linalg.lstsq\` (sklearn CPU fallback)

These are the values that match Mike's \`r2_vs_params_45000galaxies_upsampled.json\` reference (mean abs diff 0.006, max 0.029 across 150 cells).

## Changes

- Renamed \`pu_regress.py\` → \`01_extract_and_probe.py\`, \`pu_regress_pairs.py\` → \`02_aggregate_pairs.py\`
- Patched probe section: dropped CV / permutation / PCA, added \`_prep_property\` and \`_probe_published\`
- Added optional \`.npy\` upload to \`\$PU_EMB_REPO\` so downstream re-probing doesn't need a GPU
- Rewrote README around the explicit two-step flow + recipe + per-knob defaults
- Updated filename references in \`setup_hf.py\`, \`slurm/pu_regress.sh\`, \`vast/vast_regress.sh\`

## Test plan

- [x] Both scripts parse (\`python -c "import ast; ast.parse(open(p).read())"\`)
- [x] Re-ran the probe locally on cached embeddings via the new code path; values agree with Mike's reference within 0.006 mean / 0.029 max
- [ ] @shash12-ship — quick read-through of \`01_extract_and_probe.py\` probe block + README before merge

cc @shash12-ship