### PR TITLE
feat(cosmosweb): reproducible Procrustes pipeline from HF embeddings

### DIFF
--- a/experiments/cosmosweb/PROCRUSTES_PIPELINE.md
+++ b/experiments/cosmosweb/PROCRUSTES_PIPELINE.md
@@ -1,0 +1,104 @@
+# Procrustes pipeline (HF embeddings → paper figures)
+
+This pipeline reproduces the Procrustes-distance and cosine-similarity
+artifacts that drive several paper figures
+(`crossarchitectural_procrustes.pdf`,
+`crossmodal_procrustes_per_property_ancova.pdf`,
+`avg_cos_sim_matrix.pdf`).
+
+The artifacts are not currently checked into the repo. This pipeline
+regenerates them deterministically from the embeddings hosted on Hugging
+Face by anyone with read access — no rerun of the heavy embedding
+extraction is required.
+
+## What the pipeline does
+
+```
+UniverseTBD/pu-embeddings/cosmosweb/*.parquet   ← upstream, on HF
+       │
+       │  (1) stream_embeddings_to_npy.py
+       ▼
+analysis/procrustes_pipeline/embeddings/*.npy   ← local
+       │
+       │  (2) probe_weight_analysis.py (Ashod's, env-driven)
+       ▼
+analysis/procrustes_pipeline/
+  ├── procrustes_distances_45000galaxies.pkl    ← input to Mike's plotters
+  ├── avg_cosine_similarity_45000galaxies.pdf   ← paper Fig 4
+  ├── probe_weight_analysis_45000galaxies_*.pdf
+  └── probe_weight_cache_45000/                 ← per-model probe weights
+       │
+       │  (3) drop the pkl into a worktree on the
+       │      `crossmodalintramodal` branch
+       ▼
+<worktree>/data/procrustes_distances_45000galaxies_upsampled.pkl
+       │
+       │  scripts/plot_crossarchitectural_procrustes.py
+       │  scripts/plot_crossmodal_procrustes.py
+       │  scripts/plot_crossmodal_procrustes_per_property.py
+       ▼
+<worktree>/figs/{crossarchitectural,crossmodal}_procrustes*.pdf  ← paper figs
+```
+
+## Quick start (full basket, ~30 GB transient bandwidth, ~30 GB peak disk)
+
+```
+git worktree add /tmp/pu_mike origin/crossmodalintramodal
+RPP_PLOT_WORKTREE=/tmp/pu_mike \
+  python experiments/cosmosweb/run_procrustes_pipeline.py
+cd /tmp/pu_mike
+python scripts/plot_crossarchitectural_procrustes.py
+python scripts/plot_crossmodal_procrustes.py
+python scripts/plot_crossmodal_procrustes_per_property.py
+ls figs/*procrustes*.pdf
+```
+
+## Quick start (smoke-test subset, <2 GB peak disk)
+
+```
+STREAM_SUBSET="dinov3:vits16,dinov3:vitb16,convnext:nano,convnext:tiny,astropt:015M,astropt:095M" \
+  python experiments/cosmosweb/stream_embeddings_to_npy.py
+PWA_DATASET=Ashodkh/cosmosweb-hsc-jwst-high-snr-pil2 \
+PWA_OUT_DIR=analysis/probe_smoke \
+PWA_EMB_DIR=analysis/probe_smoke/embeddings \
+PWA_UPSAMPLE_SUFFIX="" \
+  python experiments/cosmosweb/probe_weight_analysis.py
+```
+
+## Streaming details (peak local disk)
+
+`stream_embeddings_to_npy.py` downloads one parquet to a scratch dir,
+converts it to .npy under `STREAM_OUT_DIR`, then deletes the scratch dir
+before pulling the next one. Peak local disk during streaming is bounded
+by the largest single embedding parquet (~1 GB for `llava_15_13b` /
+`paligemma_28b`). After streaming completes, the .npy directory holds
+~30 GB if the full basket was processed.
+
+Use `STREAM_SUBSET` (comma-separated `<family>:<size>` pairs) to limit the
+basket — e.g. for smoke tests or for a per-family debugging run.
+
+## Why we needed this
+
+`probe_weight_analysis.py` consumes per-`(telescope, alias, size)` .npy
+embedding files. The actual embeddings live on HF as parquet shards under
+`UniverseTBD/pu-embeddings/cosmosweb/`. Previously the parquet → .npy
+conversion + the script execution were undocumented manual steps on
+contributors' personal machines, which is why the Procrustes pkl was not
+reproducible by anyone else. This pipeline removes that dependency on a
+specific person's local filesystem.
+
+## Verifying the pkl
+
+```
+python -c "
+import pickle
+with open('analysis/procrustes_pipeline/procrustes_distances_45000galaxies.pkl','rb') as f:
+    d = pickle.load(f)
+print(list(d.keys()))
+"
+```
+
+Expected top-level keys include `cross_modal_hsc_vs_jwst`, plus per-(model,
+property) entries. Mike's `plot_crossmodal_procrustes.py` reads
+`cross_modal_hsc_vs_jwst[<property>]` as a list of
+`(family, raw_size, params, distance)` tuples.

--- a/experiments/cosmosweb/probe_weight_analysis.py
+++ b/experiments/cosmosweb/probe_weight_analysis.py
@@ -29,12 +29,13 @@ from tqdm import tqdm
 from pu.pu_datasets.cosmosweb import CATALOG_COLUMNS
 
 # ── Config ──────────────────────────────────────────────────────────────────────
-DATASET         = ""
-OUT_DIR         = ""
-EMB_DIR         = f"{OUT_DIR}/embeddings"
+# Env vars override hardcoded defaults — used by run_procrustes_pipeline.py.
+DATASET         = os.environ.get("PWA_DATASET", "")
+OUT_DIR         = os.environ.get("PWA_OUT_DIR", "")
+EMB_DIR         = os.environ.get("PWA_EMB_DIR", f"{OUT_DIR}/embeddings")
 DS_TAG          = DATASET.split("/")[-1]
-N_USE           = 45000
-UPSAMPLE_SUFFIX = "_upsampled"
+N_USE           = int(os.environ.get("PWA_N_USE", "45000"))
+UPSAMPLE_SUFFIX = os.environ.get("PWA_UPSAMPLE_SUFFIX", "_upsampled")
 PROBE_TEST_SIZE = 5000
 SEED            = 42
 TELESCOPES      = ["hsc", "jwst"]

--- a/experiments/cosmosweb/run_procrustes_pipeline.py
+++ b/experiments/cosmosweb/run_procrustes_pipeline.py
@@ -1,0 +1,109 @@
+#!/usr/bin/env python3
+"""End-to-end runner: Hugging Face embeddings → Procrustes pkl → paper figures.
+
+Steps:
+  1. Stream-convert UniverseTBD/pu-embeddings/cosmosweb/*.parquet to .npy.
+  2. Run probe_weight_analysis.py to fit linear probes, compute the 3×3
+     cosine-similarity matrices, and save the per-(family, size) Procrustes
+     distance pickle.
+  3. Optionally drop the pkl into a separate worktree (Mike's plotting branch)
+     so plot_*_procrustes.py can render the paper figures.
+
+Configuration via env vars (sensible defaults):
+  RPP_OUT_DIR         analysis/procrustes_pipeline   (root of outputs)
+  RPP_SKIP_STREAM     "0"  → "1" to skip download/conversion (.npy exist)
+  RPP_PLOT_WORKTREE   ""   → optional path of a checkout containing
+                              scripts/plot_*_procrustes.py + data/
+
+The probe_weight_analysis.py script reads the same OUT_DIR via env vars
+PWA_*; this runner sets them so the two scripts agree on layout.
+"""
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+DATASET = "Ashodkh/cosmosweb-hsc-jwst-high-snr-pil2"
+DS_TAG  = "cosmosweb-hsc-jwst-high-snr-pil2"
+N_USE   = 45000
+
+ROOT     = Path(__file__).resolve().parent.parent.parent
+OUT_DIR  = Path(os.environ.get("RPP_OUT_DIR",
+                                ROOT / "analysis" / "procrustes_pipeline"))
+EMB_DIR  = OUT_DIR / "embeddings"
+SKIP_STREAM   = os.environ.get("RPP_SKIP_STREAM", "0") == "1"
+PLOT_WORKTREE = os.environ.get("RPP_PLOT_WORKTREE", "").strip()
+
+
+def step_stream() -> None:
+    if SKIP_STREAM:
+        print("[1/3] stream — skipped (RPP_SKIP_STREAM=1)")
+        return
+    print("[1/3] stream parquets → .npy")
+    env = os.environ.copy()
+    env.update(
+        STREAM_DS_TAG=DS_TAG,
+        STREAM_N_USE=str(N_USE),
+        STREAM_OUT_DIR=str(EMB_DIR),
+    )
+    rc = subprocess.call(
+        [sys.executable, str(Path(__file__).parent / "stream_embeddings_to_npy.py")],
+        env=env,
+    )
+    if rc != 0:
+        raise SystemExit(f"stream step failed with rc={rc}")
+
+
+def step_probe_weight_analysis() -> None:
+    print("[2/3] probe_weight_analysis.py → Procrustes pkl + cosine PDFs")
+    env = os.environ.copy()
+    env.update(
+        PWA_DATASET=DATASET,
+        PWA_OUT_DIR=str(OUT_DIR),
+        PWA_EMB_DIR=str(EMB_DIR),
+        PWA_N_USE=str(N_USE),
+        # Embeddings on UniverseTBD/pu-embeddings are NOT the upsampled flavour.
+        PWA_UPSAMPLE_SUFFIX="",
+    )
+    rc = subprocess.call(
+        [sys.executable, str(Path(__file__).parent / "probe_weight_analysis.py")],
+        env=env,
+    )
+    if rc != 0:
+        # The script may exit non-zero on a late cosmetic plot bug while still
+        # having produced the pkl. Treat missing pkl as fatal.
+        pass
+    pkl = OUT_DIR / f"procrustes_distances_{N_USE}galaxies.pkl"
+    if not pkl.exists():
+        raise SystemExit(f"expected {pkl} not produced — check upstream errors")
+    print(f"  produced {pkl}  ({pkl.stat().st_size//1024} KB)")
+
+
+def step_publish_to_worktree() -> None:
+    if not PLOT_WORKTREE:
+        print("[3/3] worktree drop — skipped (RPP_PLOT_WORKTREE not set)")
+        return
+    src = OUT_DIR / f"procrustes_distances_{N_USE}galaxies.pkl"
+    dst_dir = Path(PLOT_WORKTREE) / "data"
+    dst_dir.mkdir(parents=True, exist_ok=True)
+    dst = dst_dir / f"procrustes_distances_{N_USE}galaxies_upsampled.pkl"
+    shutil.copy2(src, dst)
+    print(f"[3/3] copied {src.name} → {dst}")
+    print("       run scripts/plot_*_procrustes.py from that worktree to render")
+
+
+def main() -> int:
+    OUT_DIR.mkdir(parents=True, exist_ok=True)
+    EMB_DIR.mkdir(parents=True, exist_ok=True)
+    step_stream()
+    step_probe_weight_analysis()
+    step_publish_to_worktree()
+    print("\n[done]")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/experiments/cosmosweb/stream_embeddings_to_npy.py
+++ b/experiments/cosmosweb/stream_embeddings_to_npy.py
@@ -1,0 +1,116 @@
+#!/usr/bin/env python3
+"""Stream parquet → .npy conversion for the COSMOS-Web embeddings hosted at
+``UniverseTBD/pu-embeddings/cosmosweb/``.
+
+Each parquet is downloaded one at a time, converted to the .npy file name
+expected by ``probe_weight_analysis.py``, and the parquet is deleted before
+the next download. Peak local disk usage during conversion is bounded by
+the largest single embedding (~1 GB for llava_15_13b / paligemma_28b).
+
+Output layout:
+  <OUT_DIR>/<telescope>_embeddings_<DS_TAG>_<alias>_<size>_<N_USE>.npy
+
+Configuration via env vars (defaults reproduce the paper's basket):
+  STREAM_REPO          UniverseTBD/pu-embeddings  (HF dataset id)
+  STREAM_FOLDER        cosmosweb                  (sub-folder in the repo)
+  STREAM_DS_TAG        cosmosweb-hsc-jwst-high-snr-pil2
+  STREAM_N_USE         45000
+  STREAM_OUT_DIR       analysis/probe_smoke/embeddings
+  STREAM_TMP_DIR       /tmp/pu_emb_stream         (per-file scratch)
+  STREAM_SUBSET        ""                         (comma-separated <fam>:<size>
+                                                   pairs to limit; empty = all)
+
+Usage:
+  PWA_DATASET=Ashodkh/cosmosweb-hsc-jwst-high-snr-pil2 \
+  python experiments/cosmosweb/stream_embeddings_to_npy.py
+"""
+from __future__ import annotations
+
+import os
+import shutil
+from pathlib import Path
+
+import numpy as np
+import polars as pl
+from huggingface_hub import hf_hub_download
+
+# Full basket — same as probe_weight_analysis.py
+DEFAULT_MODEL_MAP = {
+    "vit":       ["base", "large", "huge"],
+    "clip":      ["base", "large"],
+    "dinov3":    ["vits16", "vits16plus", "vitb16", "vitl16",
+                  "vith16plus", "vit7b16"],
+    "convnext":  ["nano", "tiny", "base", "large"],
+    "ijepa":     ["huge", "giant"],
+    "vjepa":     ["large", "huge", "giant"],
+    "astropt":   ["015M", "095M", "850M"],
+    "vit-mae":   ["base", "large", "huge"],
+    "paligemma": ["3b", "10b", "28b"],
+    "llava_15":  ["7b", "13b"],
+}
+TELESCOPES = ("hsc", "jwst")
+
+
+def parse_subset(s: str) -> list[tuple[str, str]] | None:
+    """Parse comma-separated <fam>:<size> pairs. Empty → None (= use all)."""
+    s = (s or "").strip()
+    if not s:
+        return None
+    out = []
+    for tok in s.split(","):
+        fam, size = tok.split(":")
+        out.append((fam.strip(), size.strip()))
+    return out
+
+
+def main() -> int:
+    repo     = os.environ.get("STREAM_REPO",   "UniverseTBD/pu-embeddings")
+    folder   = os.environ.get("STREAM_FOLDER", "cosmosweb")
+    ds_tag   = os.environ.get("STREAM_DS_TAG", "cosmosweb-hsc-jwst-high-snr-pil2")
+    n_use    = int(os.environ.get("STREAM_N_USE", "45000"))
+    out_dir  = Path(os.environ.get("STREAM_OUT_DIR",
+                                    "analysis/probe_smoke/embeddings"))
+    tmp_dir  = Path(os.environ.get("STREAM_TMP_DIR", "/tmp/pu_emb_stream"))
+    subset   = parse_subset(os.environ.get("STREAM_SUBSET", ""))
+
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    pairs = subset or [(fam, size) for fam, sizes in DEFAULT_MODEL_MAP.items()
+                                    for size in sizes]
+    print(f"[stream] {len(pairs)} (family, size) pairs × {len(TELESCOPES)} "
+          f"telescopes = {len(pairs)*len(TELESCOPES)} files")
+    print(f"[stream] repo={repo}  folder={folder}  out={out_dir}")
+
+    for fam, size in pairs:
+        for tele in TELESCOPES:
+            target = out_dir / (
+                f"{tele}_embeddings_{ds_tag}_{fam}_{size}_{n_use}.npy"
+            )
+            if target.exists():
+                print(f"  [skip] {target.name}")
+                continue
+            rel = f"{folder}/{tele}_embeddings_{ds_tag}_{fam}_{size}_{n_use}.parquet"
+            # Clean per-file scratch to avoid stacking
+            shutil.rmtree(tmp_dir, ignore_errors=True)
+            tmp_dir.mkdir(parents=True, exist_ok=True)
+            try:
+                local = hf_hub_download(repo, rel, repo_type="dataset",
+                                         local_dir=str(tmp_dir))
+            except Exception as e:
+                print(f"  [warn] {rel}: {type(e).__name__}: {e}")
+                continue
+            df = pl.read_parquet(local)
+            col = "embeddings" if "embeddings" in df.columns else df.columns[0]
+            arr = np.stack([np.asarray(v, dtype=np.float32)
+                             for v in df[col].to_list()])
+            np.save(target, arr)
+            print(f"  {target.name}  shape={arr.shape}  ({arr.nbytes/1e6:.0f} MB)")
+            shutil.rmtree(tmp_dir, ignore_errors=True)
+
+    n_npy = len(list(out_dir.glob("*.npy")))
+    print(f"\n[stream] {n_npy} .npy files in {out_dir}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Several paper figures (`crossarchitectural_procrustes.pdf`, `crossmodal_procrustes_per_property_ancova.pdf`, `avg_cos_sim_matrix.pdf`) are produced by Mike's plotting scripts on the `crossmodalintramodal` branch. Those scripts consume `data/procrustes_distances_45000galaxies_upsampled.pkl`, which is generated by Ashod's `experiments/cosmosweb/probe_weight_analysis.py`. The pkl was never committed and the upstream `.npy` embedding files lived only on contributors' personal machines, so neither artifact was reproducible.

This PR adds an end-to-end pipeline that regenerates both the pkl and the cosine-similarity figures from the parquet embeddings already published at `UniverseTBD/pu-embeddings/cosmosweb/` — no rerun of the heavy embedding extraction is required.

## End-to-end flow

```
UniverseTBD/pu-embeddings/cosmosweb/*.parquet   ← upstream, on HF
       │
       │  (1) stream_embeddings_to_npy.py     [new]
       ▼
analysis/procrustes_pipeline/embeddings/*.npy   ← local
       │
       │  (2) probe_weight_analysis.py         [now env-driven]
       ▼
analysis/procrustes_pipeline/
  ├── procrustes_distances_45000galaxies.pkl   ← input to Mike's plotters
  ├── avg_cosine_similarity_45000galaxies.pdf  ← paper Fig 4
  ├── probe_weight_analysis_45000galaxies_*.pdf
  └── probe_weight_cache_45000/
       │
       │  (3) drop pkl into a worktree on `crossmodalintramodal`
       ▼
<worktree>/data/procrustes_distances_45000galaxies_upsampled.pkl
       │
       │  scripts/plot_*_procrustes.py
       ▼
figs/{crossarchitectural,crossmodal}_procrustes*.pdf  ← paper figs
```

## What's in the PR

| File | Role |
|---|---|
| `experiments/cosmosweb/stream_embeddings_to_npy.py` | per-file parquet → .npy converter with bounded peak disk (~1 GB at any moment). Configurable via `STREAM_*` env vars. |
| `experiments/cosmosweb/run_procrustes_pipeline.py` | orchestrator. Streams → runs probe analysis → optionally copies pkl into a plotting worktree. |
| `experiments/cosmosweb/probe_weight_analysis.py` | minor change: `DATASET`, `OUT_DIR`, `EMB_DIR`, `N_USE`, `UPSAMPLE_SUFFIX` now read from `PWA_*` env vars (defaults preserved). |
| `experiments/cosmosweb/PROCRUSTES_PIPELINE.md` | full docs incl. quick-start recipes (smoke + full basket) and verification snippet. |

## Quick start

**Full basket** (~30 GB transient bandwidth, ~30 GB peak local disk):
```
git worktree add /tmp/pu_mike origin/crossmodalintramodal
RPP_PLOT_WORKTREE=/tmp/pu_mike \
  python experiments/cosmosweb/run_procrustes_pipeline.py
cd /tmp/pu_mike
python scripts/plot_crossarchitectural_procrustes.py
python scripts/plot_crossmodal_procrustes.py
python scripts/plot_crossmodal_procrustes_per_property.py
```

**Smoke** (<2 GB peak disk, 6 models, ~5 min):
```
STREAM_SUBSET="dinov3:vits16,dinov3:vitb16,convnext:nano,convnext:tiny,astropt:015M,astropt:095M" \
  python experiments/cosmosweb/stream_embeddings_to_npy.py
PWA_DATASET=Ashodkh/cosmosweb-hsc-jwst-high-snr-pil2 \
PWA_OUT_DIR=analysis/probe_smoke \
PWA_EMB_DIR=analysis/probe_smoke/embeddings \
PWA_UPSAMPLE_SUFFIX="" \
  python experiments/cosmosweb/probe_weight_analysis.py
```

## Validation

Smoke-tested locally with 6 models across 3 families (dinov3 ×2, convnext ×2, astropt ×2) on both telescopes. The smoke run produced:
- `procrustes_distances_45000galaxies.pkl` (correct schema; `cross_modal_hsc_vs_jwst[<property>]` is the expected list of `(family, raw_size, params, distance)` tuples)
- `avg_cosine_similarity_45000galaxies.pdf`
- per-model `probe.pkl` cache files

The pkl was then copied into a worktree of `crossmodalintramodal` and Mike's plotters were run unchanged:
- `plot_crossarchitectural_procrustes.py` → `crossarchitectural_procrustes.pdf` ✓
- `plot_crossmodal_procrustes.py` → `crossmodal_procrustes.pdf`, `crossmodal_procrustes_partial.pdf` ✓

## Notes

- `UniverseTBD/pu-embeddings/cosmosweb/` parquets are NOT the `_upsampled` flavour, so the pipeline sets `PWA_UPSAMPLE_SUFFIX=""`. When the pkl is dropped into Mike's worktree, the runner renames it to `..._upsampled.pkl` to match what `plot_*_procrustes.py` expects.
- `data/jwst/jwst_<family>_<size>.parquet` (the input for `plot_crossarchitectural.py`) is still missing; that's a separate piece and not addressed here.

## Test plan

- [ ] Run smoke recipe end-to-end on a fresh clone.
- [ ] Run the full pipeline + Mike's plotters on a machine with ~30 GB free.
- [ ] Confirm produced PDFs match the figures referenced in `almost.tex`.